### PR TITLE
Fix requirements filename in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is intended to explore research concepts in autonomous operations in a simula
 
 Create a conda environment with the necessary packages
 
-    conda create --name onair --file requirements.txt
+    conda create --name onair --file requirements_pip.txt
 
 ## Running unit tests
 


### PR DESCRIPTION
Closes #5 

Just a readme change to fix the name of requirements_pip.txt in the instructions.