### PR TITLE
[nasa/onair#10] Find and replace render_diagnosis to render_reasoning;

### DIFF
--- a/onair/src/data_driven_components/data_driven_learning.py
+++ b/onair/src/data_driven_components/data_driven_learning.py
@@ -32,10 +32,10 @@ class DataDrivenLearning:
         for plugin in self.ai_constructs:
             plugin.apriori_training(batch_data)
 
-    def render_diagnosis(self):
+    def render_reasoning(self):
         diagnoses = {}
         for plugin in self.ai_constructs:
-            diagnoses[plugin.component_name] = plugin.render_diagnosis()
+            diagnoses[plugin.component_name] = plugin.render_reasoning()
         return diagnoses
 
 

--- a/onair/src/data_driven_components/generic_component/core.py
+++ b/onair/src/data_driven_components/generic_component/core.py
@@ -43,7 +43,7 @@ class AIPlugIn(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def render_diagnosis(self):
+    def render_reasoning(self):
         """
         System should return its diagnosis
         """

--- a/onair/src/data_driven_components/kalman/kalman_plugin.py
+++ b/onair/src/data_driven_components/kalman/kalman_plugin.py
@@ -48,7 +48,7 @@ class Plugin(AIPlugIn):
                 if len(self.frames[data_point_index]) > self.window_size: # If after adding a point to the frame, that attribute is larger than the window_size, take out the first element
                     self.frames[data_point_index].pop(0) 
 
-    def render_diagnosis(self):
+    def render_reasoning(self):
         """
         System should return its diagnosis
         """

--- a/onair/src/reasoning/agent.py
+++ b/onair/src/reasoning/agent.py
@@ -29,7 +29,7 @@ class Agent:
 
     def diagnose(self, time_step):
         """ Grab the mnemonics from the """
-        learning_system_results = self.learning_systems.render_diagnosis() 
+        learning_system_results = self.learning_systems.render_reasoning() 
         diagnosis = Diagnosis(time_step, 
                               learning_system_results,
                               self.bayesian_status,

--- a/onair/src/util/sim_io.py
+++ b/onair/src/util/sim_io.py
@@ -15,7 +15,7 @@ Utility file for sim io
 import os
 import json 
 
-def render_diagnosis(diagnosis_list):
+def render_reasoning(diagnosis_list):
     with open(os.path.join(os.environ.get('ONAIR_DIAGNOSIS_SAVE_PATH'), 'diagnosis.txt'), mode='a') as out:
         out.write('==========================================================\n')
         out.write('                        DIAGNOSIS                         \n')

--- a/test/src/data_driven_components/generic_component/test_core.py
+++ b/test/src/data_driven_components/generic_component/test_core.py
@@ -25,7 +25,7 @@ class FakeAIPlugIn(AIPlugIn):
     def update(self):
         return None
 
-    def render_diagnosis(self):
+    def render_reasoning(self):
         return dict()
 
 class IncompleteFakeAIPlugIn(AIPlugIn):
@@ -42,8 +42,8 @@ class BadFakeAIPlugIn(AIPlugIn):
     def update(self):
         return super().update()
 
-    def render_diagnosis(self):
-        return super().render_diagnosis()
+    def render_reasoning(self):
+        return super().render_reasoning()
         
 # abstract methods tests
 def test_AIPlugIn_raises_error_because_of_unimplemented_abstract_methods():
@@ -56,7 +56,7 @@ def test_AIPlugIn_raises_error_because_of_unimplemented_abstract_methods():
     assert "Can't instantiate abstract class AIPlugIn with" in e_info.__str__()
     assert "apriori_training" in e_info.__str__()
     assert "update" in e_info.__str__()
-    assert "render_diagnosis" in e_info.__str__()
+    assert "render_reasoning" in e_info.__str__()
 
 # Incomplete plugin call tests
 def test_AIPlugIn_raises_error_when_an_inherited_class_is_instantiated_because_abstract_methods_are_not_implemented_by_that_class():
@@ -69,14 +69,14 @@ def test_AIPlugIn_raises_error_when_an_inherited_class_is_instantiated_because_a
     assert "Can't instantiate abstract class IncompleteFakeAIPlugIn with" in e_info.__str__()
     assert "apriori_training" in e_info.__str__()
     assert "update" in e_info.__str__()
-    assert "render_diagnosis" in e_info.__str__()
+    assert "render_reasoning" in e_info.__str__()
 
 def test_AIPlugIn_raises_error_when_an_inherited_class_calls_abstract_methods_in_parent():
     # Act
     cut = BadFakeAIPlugIn.__new__(BadFakeAIPlugIn)
 
     # populate list with the functions that should raise exceptions when called.
-    not_implemented_functions = [cut.update, cut.apriori_training, cut.render_diagnosis]
+    not_implemented_functions = [cut.update, cut.apriori_training, cut.render_reasoning]
     for fnc in not_implemented_functions:
         with pytest.raises(NotImplementedError) as e_info:
             fnc()

--- a/test/src/data_driven_components/kalman/test_kalman_plugin.py
+++ b/test/src/data_driven_components/kalman/test_kalman_plugin.py
@@ -255,7 +255,7 @@ def test_Kalman_update_will_not_pop_first_index_of_frames_data_points_when_windo
     assert cut.frames == expected_result
 
 # test render diagnosis
-def test_Kalman_render_diagnosis_returns_value_returned_by_frame_diagnosis_function(mocker):
+def test_Kalman_render_reasoning_returns_value_returned_by_frame_diagnosis_function(mocker):
     # Arrange
     fake_frames = MagicMock()
     fake_headers = MagicMock()
@@ -268,7 +268,7 @@ def test_Kalman_render_diagnosis_returns_value_returned_by_frame_diagnosis_funct
     mocker.patch.object(cut, 'frame_diagnosis', return_value=forced_frame_diagnose_return)
     
     # Act
-    result = cut.render_diagnosis()
+    result = cut.render_reasoning()
 
     # Assert
     assert result == forced_frame_diagnose_return

--- a/test/src/data_driven_components/test_data_driven_learning.py
+++ b/test/src/data_driven_components/test_data_driven_learning.py
@@ -173,19 +173,19 @@ def test_DataDrivenLearning_apriori_training_calls_apriori_training_on_each_ai_c
         assert cut.ai_constructs[i].apriori_training.call_args_list[0].args == (arg_batch_data, )
     assert result == None
 
-# render_diagnosis tests
-def test_DataDrivenLearning_render_diagnosis_returns_empty_dict_when_instance_ai_constructs_is_empty(mocker):
+# render_reasoning tests
+def test_DataDrivenLearning_render_reasoning_returns_empty_dict_when_instance_ai_constructs_is_empty(mocker):
     # Arrange
     cut = DataDrivenLearning.__new__(DataDrivenLearning)
     cut.ai_constructs = []
 
     # Act
-    result = cut.render_diagnosis()
+    result = cut.render_reasoning()
 
     # Assert
     assert result == {}
 
-def test_DataDrivenLearning_render_diagnosis_returns_dict_of_each_ai_construct_as_key_to_the_result_of_its_render_diagnosis_when_instance_ai_constructs_is_occupied(mocker):
+def test_DataDrivenLearning_render_reasoning_returns_dict_of_each_ai_construct_as_key_to_the_result_of_its_render_reasoning_when_instance_ai_constructs_is_occupied(mocker):
     # Arrange
     cut = DataDrivenLearning.__new__(DataDrivenLearning)
     cut.ai_constructs = []
@@ -195,17 +195,17 @@ def test_DataDrivenLearning_render_diagnosis_returns_dict_of_each_ai_construct_a
     num_fake_ai_constructs = pytest.gen.randint(1, 10) # arbitrary, from 1 to 10 (0 has own test)
     for i in range(num_fake_ai_constructs):
         fake_ai_construct = MagicMock()
-        forced_return_ai_construct_render_diagnosis = MagicMock()
+        forced_return_ai_construct_render_reasoning = MagicMock()
         cut.ai_constructs.append(fake_ai_construct)
-        mocker.patch.object(fake_ai_construct, 'render_diagnosis', return_value=forced_return_ai_construct_render_diagnosis)
+        mocker.patch.object(fake_ai_construct, 'render_reasoning', return_value=forced_return_ai_construct_render_reasoning)
         fake_ai_construct.component_name = MagicMock()
-        expected_result[fake_ai_construct.component_name] = forced_return_ai_construct_render_diagnosis
+        expected_result[fake_ai_construct.component_name] = forced_return_ai_construct_render_reasoning
 
     # Act
-    result = cut.render_diagnosis()
+    result = cut.render_reasoning()
 
     # Assert
     for i in range(num_fake_ai_constructs):
-        assert cut.ai_constructs[i].render_diagnosis.call_count == 1
-        assert cut.ai_constructs[i].render_diagnosis.call_args_list[0].args == ()
+        assert cut.ai_constructs[i].render_reasoning.call_count == 1
+        assert cut.ai_constructs[i].render_reasoning.call_args_list[0].args == ()
     assert result == expected_result

--- a/test/src/util/test_sim_io.py
+++ b/test/src/util/test_sim_io.py
@@ -10,7 +10,7 @@
 from mock import MagicMock
 import onair.src.util.sim_io
 
-def test_sim_io_render_diagnosis_writes_txt_and_csv_files_even_when_list_is_empty(mocker):
+def test_sim_io_render_reasoning_writes_txt_and_csv_files_even_when_list_is_empty(mocker):
   # Arrange
   SAVE_PATH = 'ONAIR_DIAGNOSIS_SAVE_PATH'
   diag1 = MagicMock()
@@ -26,7 +26,7 @@ def test_sim_io_render_diagnosis_writes_txt_and_csv_files_even_when_list_is_empt
   mocker.patch('builtins.open', return_value=fake_file)
 
   # Act
-  onair.src.util.sim_io.render_diagnosis(arg_diagnosis_list)
+  onair.src.util.sim_io.render_reasoning(arg_diagnosis_list)
 
   # Assert
   assert open.call_count == 2
@@ -44,7 +44,7 @@ def test_sim_io_render_diagnosis_writes_txt_and_csv_files_even_when_list_is_empt
   assert open.call_args_list[1].kwargs == {'mode':'a'}
   assert fake_file_iterator.write.call_args_list[3].args == ('time_step, cohens_kappa, faults, subgraph\n',)
   
-def test_sim_io_render_diagnosis_writes_txt_and_csv_files_with_entry_for_each_given_diagnosis_in_list(mocker):
+def test_sim_io_render_reasoning_writes_txt_and_csv_files_with_entry_for_each_given_diagnosis_in_list(mocker):
   # Arrange
   SAVE_PATH = 'ONAIR_DIAGNOSIS_SAVE_PATH'
   diag1 = MagicMock()
@@ -70,7 +70,7 @@ def test_sim_io_render_diagnosis_writes_txt_and_csv_files_with_entry_for_each_gi
     arg_diagnosis_list.append(fake_diag)
 
   # Act
-  onair.src.util.sim_io.render_diagnosis(arg_diagnosis_list)
+  onair.src.util.sim_io.render_reasoning(arg_diagnosis_list)
 
   # Assert
   assert open.call_count == 2


### PR DESCRIPTION
Easy find and replace to `render_reasoning`, all tests still passing and coverage remains the same.