### PR TITLE
Remove leftover __init__ calls in tests after updates

### DIFF
--- a/test/onair/src/systems/test_vehicle_rep.py
+++ b/test/onair/src/systems/test_vehicle_rep.py
@@ -329,7 +329,6 @@ def test_VehicleRepresentation_get_state_information_calls_render_reasoning_on_k
     fake_knowledge_synthesis_construct.component_name = 'foo'
 
     cut = VehicleRepresentation.__new__(VehicleRepresentation)
-    cut.__init__(arg_headers, arg_tests) # Init to fill attributes
     cut.knowledge_synthesis_constructs = [fake_knowledge_synthesis_construct]
     mocker.patch.object(fake_knowledge_synthesis_construct, 'render_reasoning', return_value=fake_render_reasoning_result)
 


### PR DESCRIPTION
Removed __init__ call in Vehicle Rep get_state_information test, leftover from last round of unit test updates.