### PR TITLE
63 remove orjson dependency switch to python standard json

### DIFF
--- a/onair/data_handling/tlm_json_parser.py
+++ b/onair/data_handling/tlm_json_parser.py
@@ -8,7 +8,7 @@
 # See "NOSA GSC-19165-1 OnAIR.pdf"
 
 import ast
-import orjson
+import json
 
 # parse tlm config json file
 def parseTlmConfJson(file_path):
@@ -83,6 +83,6 @@ def parseJson(path):
     file = open(path, 'rb')
     file_str = file.read()
 
-    data = orjson.loads(file_str)
+    data = json.loads(file_str)
     file.close()
     return data

--- a/onair/utils/tlm_json_converter.py
+++ b/onair/utils/tlm_json_converter.py
@@ -7,7 +7,7 @@
 # Licensed under the NASA Open Source Agreement version 1.3
 # See "NOSA GSC-19165-1 OnAIR.pdf"
 
-import orjson
+import json
 import os
 import ast
 import argparse
@@ -116,7 +116,7 @@ def mergeDicts(dict1, dict2):
 def writeToJson(path, data):
     file = open(path, 'wb')
 
-    file.write(orjson.dumps(data, option=orjson.OPT_INDENT_2))
+    file.write(json.dumps(data, indent=2))
     file.close()
 
 def str2lst(string):

--- a/onair/utils/tlm_json_converter.py
+++ b/onair/utils/tlm_json_converter.py
@@ -16,11 +16,11 @@ import argparse
 
 # convert tlm txt config file to json file
 def convertTlmToJson(tlm, json):
-    tlm_path = getConfigPath(tlm)
-    json_path = getConfigPath(json)
-    data = parseTlmConfTxt(tlm_path)
+    #tlm_path = getConfigPath(tlm)
+    #json_path = getConfigPath(json)
+    data = parseTlmConfTxt(tlm)
     json_data = convertTlmDictToJsonDict(data)
-    writeToJson(json_path, json_data)
+    writeToJson(json, json_data)
     
 # convert tlm data format to readable json
 def convertTlmDictToJsonDict(data):
@@ -60,7 +60,7 @@ def getJsonData(label, mnemonics, description):
     return json_data
 
 # parse tlm config files in original txt format
-def parseTlmConfTxt(file_path):   
+def parseTlmConfTxt(file_path):
     f = open(file_path, 'r')
     data_str = f.read()
     f.close()
@@ -114,7 +114,7 @@ def mergeDicts(dict1, dict2):
             dict1[key] = dict2[key]
 
 def writeToJson(path, data):
-    file = open(path, 'wb')
+    file = open(path, 'w')
 
     file.write(json.dumps(data, indent=2))
     file.close()

--- a/onair/utils/tlm_json_converter.py
+++ b/onair/utils/tlm_json_converter.py
@@ -16,11 +16,11 @@ import argparse
 
 # convert tlm txt config file to json file
 def convertTlmToJson(tlm, json):
-    #tlm_path = getConfigPath(tlm)
-    #json_path = getConfigPath(json)
-    data = parseTlmConfTxt(tlm)
+    tlm_path = getConfigPath(tlm)
+    json_path = getConfigPath(json)
+    data = parseTlmConfTxt(tlm_path)
     json_data = convertTlmDictToJsonDict(data)
-    writeToJson(json, json_data)
+    writeToJson(json_path, json_data)
     
 # convert tlm data format to readable json
 def convertTlmDictToJsonDict(data):

--- a/requirements_pip.txt
+++ b/requirements_pip.txt
@@ -1,7 +1,6 @@
 coverage==6.5.0
 mock==4.0.3
 numpy==1.23.4
-orjson==3.8.8
 pandas==1.5.1
 pytest==7.2.0
 pytest-mock==3.10.0

--- a/test/onair/data_handling/test_tlm_json_parser.py
+++ b/test/onair/data_handling/test_tlm_json_parser.py
@@ -434,7 +434,7 @@ def test_tlm_json_parser_str2lst_prints_message_when_ast_literal_eval_receives_g
     assert result == None
 
 # parseJson tests
-def test_tlm_json_parser_parseJson_opens_given_path_and_returns_data_returned_by_orjson(mocker):
+def test_tlm_json_parser_parseJson_opens_given_path_and_returns_data_returned_by_json(mocker):
     # Arrange
     arg_path = MagicMock()
 
@@ -444,7 +444,7 @@ def test_tlm_json_parser_parseJson_opens_given_path_and_returns_data_returned_by
 
     mocker.patch(tlm_json_parser.__name__ + '.open', return_value=fake_file)
     mocker.patch.object(fake_file, 'read', return_value=fake_file_str)
-    mocker.patch(tlm_json_parser.__name__ + '.orjson.loads', return_value=fake_file_data)
+    mocker.patch(tlm_json_parser.__name__ + '.json.loads', return_value=fake_file_data)
     mocker.patch.object(fake_file, 'close')
 
     # Act
@@ -454,7 +454,7 @@ def test_tlm_json_parser_parseJson_opens_given_path_and_returns_data_returned_by
     assert tlm_json_parser.open.call_count == 1
     assert tlm_json_parser.open.call_args_list[0].args == (arg_path, 'rb')
     assert fake_file.read.call_count == 1
-    assert tlm_json_parser.orjson.loads.call_count == 1
-    assert tlm_json_parser.orjson.loads.call_args_list[0].args == (fake_file_str, )
+    assert tlm_json_parser.json.loads.call_count == 1
+    assert tlm_json_parser.json.loads.call_args_list[0].args == (fake_file_str, )
     assert fake_file.close.call_count == 1
     assert result == fake_file_data

--- a/test/onair/utils/test_tlm_json_converter.py
+++ b/test/onair/utils/test_tlm_json_converter.py
@@ -633,7 +633,7 @@ def test_tlm_json_converter_writeJson_opens_given_path_and_writes_data_using_jso
     
     # Assert
     assert tlm_json_converter.open.call_count == 1
-    assert tlm_json_converter.open.call_args_list[0].args == (arg_path, 'wb')
+    assert tlm_json_converter.open.call_args_list[0].args == (arg_path, 'w')
     assert tlm_json_converter.json.dumps.call_count == 1
     assert tlm_json_converter.json.dumps.call_args_list[0].args == (arg_data, )
     assert tlm_json_converter.json.dumps.call_args_list[0].kwargs == {'indent' : 2}

--- a/test/onair/utils/test_tlm_json_converter.py
+++ b/test/onair/utils/test_tlm_json_converter.py
@@ -615,7 +615,7 @@ def test_tlm_json_converter_mergeDicts_returns_negative_one_if_arg_dict2_is_not_
     assert result == -1
 
 # writeToJson tests
-def test_tlm_json_converter_writeJson_opens_given_path_and_writes_data_using_orjson(mocker):
+def test_tlm_json_converter_writeJson_opens_given_path_and_writes_data_using_json(mocker):
     # Arrange
     arg_path = MagicMock()
     arg_data = MagicMock()
@@ -625,7 +625,7 @@ def test_tlm_json_converter_writeJson_opens_given_path_and_writes_data_using_orj
 
     mocker.patch(tlm_json_converter.__name__ + '.open', return_value=fake_file)
     mocker.patch.object(fake_file, 'write')
-    mocker.patch(tlm_json_converter.__name__ + '.orjson.dumps', return_value=fake_json_data)
+    mocker.patch(tlm_json_converter.__name__ + '.json.dumps', return_value=fake_json_data)
     mocker.patch.object(fake_file, 'close')
 
     # Act
@@ -634,9 +634,9 @@ def test_tlm_json_converter_writeJson_opens_given_path_and_writes_data_using_orj
     # Assert
     assert tlm_json_converter.open.call_count == 1
     assert tlm_json_converter.open.call_args_list[0].args == (arg_path, 'wb')
-    assert tlm_json_converter.orjson.dumps.call_count == 1
-    assert tlm_json_converter.orjson.dumps.call_args_list[0].args == (arg_data, )
-    assert tlm_json_converter.orjson.dumps.call_args_list[0].kwargs == {'option' : tlm_json_converter.orjson.OPT_INDENT_2}
+    assert tlm_json_converter.json.dumps.call_count == 1
+    assert tlm_json_converter.json.dumps.call_args_list[0].args == (arg_data, )
+    assert tlm_json_converter.json.dumps.call_args_list[0].kwargs == {'indent' : 2}
     assert fake_file.write.call_count == 1
     assert fake_file.write.call_args_list[0].args == (fake_json_data, )
     assert fake_file.close.call_count == 1


### PR DESCRIPTION
Switch from orjson to json.

Closes #63 

Unit tests all pass. No change to coverage.

Functional tests run:
* default config produces same output (`python3.9 driver.py`)
* Converted old 42 .txt config files to json using the util script: same results