### PR TITLE
Updates to allow conftest-seed argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ From the parent directory of your local repository:
 python driver.py -t
 ```
 
+#### A few optional settings for the driver.py file
+Options that may be added to the driver.py test run. Use these at your own discretion.
+
+`--conftest-seed=###` - set the random values seed for this run  
+`--randomly-seed=###` - set the random order seed for this run  
+`--verbose` or `-v` - set verbosity level, also -vv, -vvv, etc.  
+
+NOTE: Running tests will output results using provided seeds, but each seed is random when not set directly.  
+Example start of test output:
+```
+Using --conftest-seed=1691289424
+===== test session starts =======
+platform linux -- Python 3.11.2, pytest-7.2.0, pluggy-1.3.0
+Using --randomly-seed=1956010105
+```
+Copy and paste previously output seeds (or type them out) as the arguments to repeat results.
+
 ### Running pytest directly from command line
 
 For the equivalent of the driver.py run:
@@ -49,11 +66,16 @@ python -m coverage run --branch --source=onair,plugins -m pytest ./test/
 `-m pytest` - tells coverage what test runner (framework) to wrap  
 `./test` - run all tests found in this directory and subdirectories  
 
-#### A few optional settings
+#### A few optional settings for the command line
 Options that may be added to the command line test run. Use these at your own discretion.
 
 `--disable-warnings` - removes the warning reports, but displays count (i.e., 124 passed, 1 warning in 0.65s)  
 `-p no:randomly` - ONLY required to stop random order testing IFF pytest-randomly installed
+`--conftest-seed=###` - set the random values seed for this run  
+`--randomly-seed=###` - set the random order seed for this run  
+`--verbose` or `-v` - set verbosity level, also -vv, -vvv, etc.  
+
+NOTE: see note about seeds in driver.py section above
 
 ### To view testing line coverage after run:
 NOTE: you may or may not need the `python -m` to run coverage report or html

--- a/conftest.py
+++ b/conftest.py
@@ -9,14 +9,19 @@
 
 import pytest
 import random
-import datetime
+from time import time
 from mock import MagicMock
 import sys
 
-def pytest_configure():
-  seed = datetime.datetime.now().timestamp()
+def pytest_addoption(parser):
+  parser.addoption("--conftest-seed", action="store", type=int, default=None)
+
+def pytest_configure(config):
+  seed = config.getoption("--conftest-seed")
+  if config.getoption("--conftest-seed") == None:
+    seed = int(time())
   pytest.gen = random.Random(seed)
-  print(f"conftest random seed = {seed}")
+  print(f"Using --conftest-seed={seed}")
 
   # Mock simdkalman for kalman_plugin testing
   simdkalman = MagicMock()


### PR DESCRIPTION
### conftest.py

*   Added argument for conftest-seed
-   When not set, now uses integer of time.time() as random seed
-   When set uses provided seed
-   Simplified to integer for easier selection in terminal for copy/paste
-   Simplified to just use time from time and not datetime

### driver.py

-   Added verbosity, conftest-seed and randomly-seed as optional args
-   Each of these is passed to pytest.main but otherwise unused
-   Verbosity could be used in other capacity, but not currently
-   Updated how coverage and pytest are imported and used
  -  no longer import pytest or coverage when not testing
  -  changed cleanup import to only bring in the function used
    -  necessary because `import` moved into function where use of `from x import *` is not valid
  -   onair imports are imported regardless of mode even though moved into main
  -   no separate function to run tests required and it was removed

### README.md
-  Updated for new usages of commands