### PR TITLE
89 remove pandas dep

### DIFF
--- a/onair/data_handling/csv_parser.py
+++ b/onair/data_handling/csv_parser.py
@@ -27,9 +27,8 @@ class DataSource(OnAirDataSource):
 ##### INITIAL PROCESSING ####
     def parse_csv_data(self, data_file):
         #Read in the data set
-        csv_file = open(data_file, 'r')
+        csv_file = open(data_file, 'r', newline='')
         dataset = csv.reader(csv_file, delimiter=',')
-        #dataset = dataset.loc[:, ~dataset.columns.str.contains('^Unnamed')]
 
         #Initialize the entire data dictionary
         all_data = []
@@ -61,32 +60,3 @@ class DataSource(OnAirDataSource):
     # Return whether or not the index has finished traveling through the data
     def has_more(self):
         return self.frame_index < len(self.sim_data)
-
-def floatify_input(_input, remove_str=False):
-    floatified = []
-    for i in _input:
-        try:
-            x = float(i)
-            floatified.append(x)
-        except ValueError:
-            try:
-                x = convert_str_to_timestamp(i)
-                floatified.append(x)
-            except:
-                if remove_str == False:
-                    floatified.append(0.0)
-                else:
-                    continue
-                continue
-    return floatified
-
-def convert_str_to_timestamp(time_str):
-    try:
-        t = datetime.datetime.strptime(time_str, '%Y-%j-%H:%M:%S.%f')
-        return t.timestamp()
-    except:
-        min_sec = time_str.split(':')
-        current = datetime.datetime.now()
-        # Use 1 am on Jan 1st, 2000 as the date if only minutes and seconds are specified
-        t = datetime.datetime(2000, 1, 1, 1, int(min_sec[0]), int(min_sec[1]), 0)
-        return t.timestamp()

--- a/onair/data_handling/csv_parser.py
+++ b/onair/data_handling/csv_parser.py
@@ -87,5 +87,6 @@ def convert_str_to_timestamp(time_str):
     except:
         min_sec = time_str.split(':')
         current = datetime.datetime.now()
-        t = datetime.datetime(current.year, current.month, current.day, current.hour, int(min_sec[0]), int(min_sec[1]), 0)
+        # Use 1 am on Jan 1st, 2000 as the date if only minutes and seconds are specified
+        t = datetime.datetime(2000, 1, 1, 1, int(min_sec[0]), int(min_sec[1]), 0)
         return t.timestamp()

--- a/onair/data_handling/csv_parser.py
+++ b/onair/data_handling/csv_parser.py
@@ -27,20 +27,22 @@ class DataSource(OnAirDataSource):
 ##### INITIAL PROCESSING ####
     def parse_csv_data(self, data_file):
         #Read in the data set
-        csv_file = open(data_file, 'r', newline='')
-        dataset = csv.reader(csv_file, delimiter=',')
 
-        #Initialize the entire data dictionary
         all_data = []
-        index = 0
-        for row in dataset:
-            if index == 0:
-                # Skip first row (headers)
-                pass
-            else:
-                rowVals = floatify_input(list(row))
-                all_data.append(rowVals)
-            index = index + 1
+
+        with open(data_file, 'r', newline='') as csv_file:
+            dataset = csv.reader(csv_file, delimiter=',')
+
+            #Initialize the entire data dictionary
+            index = 0
+            for row in dataset:
+                if index == 0:
+                    # Skip first row (headers)
+                    pass
+                else:
+                    rowVals = floatify_input(list(row))
+                    all_data.append(rowVals)
+                index = index + 1
 
         return all_data
 

--- a/onair/data_handling/parser_util.py
+++ b/onair/data_handling/parser_util.py
@@ -9,7 +9,6 @@
 
 import os
 from .tlm_json_parser import parseTlmConfJson, str2lst
-from pandas import to_datetime
 import datetime
 
 def extract_meta_data_handle_ss_breakdown(meta_data_file, ss_breakdown):
@@ -42,29 +41,3 @@ def extract_meta_data(meta_data_file):
                 test_assign[j] = test + limits
 
     return configs
-
-def floatify_input(_input, remove_str=False):
-    floatified = []
-    for i in _input:
-        try:
-            x = float(i)
-            floatified.append(x)
-        except ValueError:
-            try:
-                x = convert_str_to_timestamp(i)
-                floatified.append(x)
-            except:
-                if remove_str == False:
-                    floatified.append(0.0)
-                else:
-                    continue
-                continue
-    return floatified
-
-def convert_str_to_timestamp(time_str):
-    try:
-        t = to_datetime(time_str)
-        return t.timestamp()
-    except:
-        t = datetime.datetime.strptime(time_str[:24], '%Y-%j-%H:%M:%S.%f')
-        return t.timestamp()

--- a/onair/data_handling/parser_util.py
+++ b/onair/data_handling/parser_util.py
@@ -41,3 +41,31 @@ def extract_meta_data(meta_data_file):
                 test_assign[j] = test + limits
 
     return configs
+
+def floatify_input(_input, remove_str=False):
+    floatified = []
+    for i in _input:
+        try:
+            x = float(i)
+            floatified.append(x)
+        except ValueError:
+            try:
+                x = convert_str_to_timestamp(i)
+                floatified.append(x)
+            except:
+                if remove_str == False:
+                    floatified.append(0.0)
+                else:
+                    continue
+                continue
+    return floatified
+
+def convert_str_to_timestamp(time_str):
+    try:
+        t = datetime.datetime.strptime(time_str, '%Y-%j-%H:%M:%S.%f')
+        return t.timestamp()
+    except:
+        min_sec = time_str.split(':')
+        # Use 1 am on Jan 1st, 2000 as the date if only minutes and seconds are specified
+        t = datetime.datetime(2000, 1, 1, 1, int(min_sec[0]), int(min_sec[1]), 0)
+        return t.timestamp()

--- a/requirements_pip.txt
+++ b/requirements_pip.txt
@@ -1,7 +1,6 @@
 coverage==6.5.0
 mock==4.0.3
 numpy==1.23.4
-pandas==1.5.1
 pytest==7.2.0
 pytest-mock==3.10.0
 pytest-randomly==3.12.0

--- a/test/onair/data_handling/test_csv_parser.py
+++ b/test/onair/data_handling/test_csv_parser.py
@@ -40,7 +40,9 @@ def test_CSV_parse_csv_data_returns_empty_list_when_parsed_dataset_is_empty(mock
     # Arrange
     arg_dataFile = MagicMock()
 
+    fake_file_iterator = MagicMock()
     fake_csv_file = MagicMock()
+    fake_csv_file.configure_mock(**{'__enter__.return_value': fake_file_iterator})
     fake_dataset = []
     forced_return_contains = MagicMock()
     fake_second_data_set = MagicMock()
@@ -61,7 +63,7 @@ def test_CSV_parse_csv_data_returns_empty_list_when_parsed_dataset_is_empty(mock
     assert csv_parser.open.call_args_list[0].args == (arg_dataFile, 'r')
     assert csv_parser.open.call_args_list[0].kwargs == ({'newline':''})
     assert csv_parser.csv.reader.call_count == 1
-    assert csv_parser.csv.reader.call_args_list[0].args == (fake_csv_file, )
+    assert csv_parser.csv.reader.call_args_list[0].args == (fake_file_iterator, )
     assert csv_parser.csv.reader.call_args_list[0].kwargs == ({'delimiter':','})
     assert csv_parser.floatify_input.call_count == 0
 
@@ -71,7 +73,9 @@ def test_CSV_parse_csv_data_returns_empty_list_when_parsed_dataset_is_just_heade
     # Arrange
     arg_dataFile = MagicMock()
 
+    fake_file_iterator = MagicMock()
     fake_csv_file = MagicMock()
+    fake_csv_file.configure_mock(**{'__enter__.return_value': fake_file_iterator})
     fake_dataset = [['fake column header', 'another fake column header']]
     forced_return_contains = MagicMock()
     fake_second_data_set = MagicMock()
@@ -91,7 +95,7 @@ def test_CSV_parse_csv_data_returns_empty_list_when_parsed_dataset_is_just_heade
     assert csv_parser.open.call_count == 1
     assert csv_parser.open.call_args_list[0].args == (arg_dataFile, 'r')
     assert csv_parser.csv.reader.call_count == 1
-    assert csv_parser.csv.reader.call_args_list[0].args == (fake_csv_file, )
+    assert csv_parser.csv.reader.call_args_list[0].args == (fake_file_iterator, )
     assert csv_parser.csv.reader.call_args_list[0].kwargs == ({'delimiter':','})
     assert csv_parser.floatify_input.call_count == 0
 
@@ -102,7 +106,9 @@ def test_CSV_parse_csv_data_returns_list_of_row_values_when_parsed_dataset(mocke
     # Arrange
     arg_dataFile = MagicMock()
 
+    fake_file_iterator = MagicMock()
     fake_csv_file = MagicMock()
+    fake_csv_file.configure_mock(**{'__enter__.return_value': fake_file_iterator})
     fake_dataset = [['fake column header', 'another fake column header']]
     expected_result_list = []
     num_fake_rows = pytest.gen.randint(1, 10) # arbitrary, from 1 to 10
@@ -124,7 +130,7 @@ def test_CSV_parse_csv_data_returns_list_of_row_values_when_parsed_dataset(mocke
     assert csv_parser.open.call_count == 1
     assert csv_parser.open.call_args_list[0].args == (arg_dataFile, 'r')
     assert csv_parser.csv.reader.call_count == 1
-    assert csv_parser.csv.reader.call_args_list[0].args == (fake_csv_file, )
+    assert csv_parser.csv.reader.call_args_list[0].args == (fake_file_iterator, )
     assert csv_parser.csv.reader.call_args_list[0].kwargs == ({'delimiter':','})
     assert csv_parser.floatify_input.call_count == num_fake_rows
 

--- a/test/onair/data_handling/test_csv_parser.py
+++ b/test/onair/data_handling/test_csv_parser.py
@@ -36,16 +36,12 @@ def test_CSV_process_data_file_sets_sim_data_to_parse_csv_data_return_and_frame_
     assert pytest.cut.frame_index == 0
 
 # CSV parse_csv_data tests
-def test_CSV_parse_csv_data_returns_empty_list_when_parsed_dataset_from_given_dataFile_call_to_iterrows_returns_empty(mocker, setup_teardown):
+def test_CSV_parse_csv_data_returns_empty_list_when_parsed_dataset_is_empty(mocker, setup_teardown):
     # Arrange
     arg_dataFile = MagicMock()
 
-    fake_initial_data_set = MagicMock()
-    fake_initial_data_set.loc = MagicMock()
-    fake_columns_str = MagicMock()
-    fake_columns = MagicMock()
-    fake_columns.str = fake_columns_str
-    fake_initial_data_set.columns = fake_columns
+    fake_csv_file = MagicMock()
+    fake_dataset = []
     forced_return_contains = MagicMock()
     fake_second_data_set = MagicMock()
     fake_second_data_set.columns = MagicMock()
@@ -53,113 +49,86 @@ def test_CSV_parse_csv_data_returns_empty_list_when_parsed_dataset_from_given_da
 
     expected_result = []
 
-    mocker.patch(csv_parser.__name__ + '.pd.read_csv', return_value=fake_initial_data_set)
-    mocker.patch.object(fake_columns_str, 'contains', return_value=forced_return_contains)
-    mocker.patch.object(fake_initial_data_set, 'loc.__getitem__', return_value=fake_second_data_set)
-    mocker.patch.object(fake_initial_data_set, 'iterrows', return_value=[])
+    mocker.patch(csv_parser.__name__ + '.open', return_value = fake_csv_file)
+    mocker.patch(csv_parser.__name__ + '.csv.reader', return_value = fake_dataset)
+    mocker.patch(csv_parser.__name__ + '.floatify_input')
 
     # Act
     result = pytest.cut.parse_csv_data(arg_dataFile)
 
     # Assert
-    assert csv_parser.pd.read_csv.call_count == 1
-    assert csv_parser.pd.read_csv.call_args_list[0].args == (arg_dataFile, )
-    assert csv_parser.pd.read_csv.call_args_list[0].kwargs == {'delimiter':',', 'header':0, 'dtype':str}
-    assert fake_columns_str.contains.call_count == 1
-    assert fake_columns_str.contains.call_args_list[0].args == ('^Unnamed', )
-    assert fake_initial_data_set.loc.__getitem__.call_args_list[0].args[0][0] == slice(None, None, None)
-    assert fake_initial_data_set.loc.__getitem__.call_args_list[0].args[0][1] == ~forced_return_contains
+    assert csv_parser.open.call_count == 1
+    assert csv_parser.open.call_args_list[0].args == (arg_dataFile, 'r')
+    assert csv_parser.open.call_args_list[0].kwargs == ({'newline':''})
+    assert csv_parser.csv.reader.call_count == 1
+    assert csv_parser.csv.reader.call_args_list[0].args == (fake_csv_file, )
+    assert csv_parser.csv.reader.call_args_list[0].kwargs == ({'delimiter':','})
+    assert csv_parser.floatify_input.call_count == 0
+
     assert result == expected_result
 
-def test_CSV_parse_csv_data_returns_list_of_row_values_when_parsed_dataset_from_given_dataFile_call_to_iterrows_returns_iterator(mocker, setup_teardown):
+def test_CSV_parse_csv_data_returns_empty_list_when_parsed_dataset_is_just_headers(mocker, setup_teardown):
     # Arrange
     arg_dataFile = MagicMock()
 
-    fake_initial_data_set = MagicMock()
-    fake_loc = MagicMock()
-    fake_initial_data_set.loc = fake_loc
-    fake_columns_str = MagicMock()
-    fake_columns = MagicMock()
-    fake_columns.str = fake_columns_str
-    fake_initial_data_set.columns = fake_columns
+    fake_csv_file = MagicMock()
+    fake_dataset = [['fake column header', 'another fake column header']]
     forced_return_contains = MagicMock()
     fake_second_data_set = MagicMock()
     fake_second_data_set.columns = MagicMock()
     fake_second_data_set.columns.values = set()
-    fake_iterrows = []
+
+    expected_result = []
+
+    mocker.patch(csv_parser.__name__ + '.open', return_value = fake_csv_file)
+    mocker.patch(csv_parser.__name__ + '.csv.reader', return_value = fake_dataset)
+    mocker.patch(csv_parser.__name__ + '.floatify_input')
+
+    # Act
+    result = pytest.cut.parse_csv_data(arg_dataFile)
+
+    # Assert
+    assert csv_parser.open.call_count == 1
+    assert csv_parser.open.call_args_list[0].args == (arg_dataFile, 'r')
+    assert csv_parser.csv.reader.call_count == 1
+    assert csv_parser.csv.reader.call_args_list[0].args == (fake_csv_file, )
+    assert csv_parser.csv.reader.call_args_list[0].kwargs == ({'delimiter':','})
+    assert csv_parser.floatify_input.call_count == 0
+
+    assert result == expected_result
+
+
+def test_CSV_parse_csv_data_returns_list_of_row_values_when_parsed_dataset(mocker, setup_teardown):
+    # Arrange
+    arg_dataFile = MagicMock()
+
+    fake_csv_file = MagicMock()
+    fake_dataset = [['fake column header', 'another fake column header']]
     expected_result_list = []
-    num_fake_rows = pytest.gen.randint(1, 10) # arbitrary, from 1 to 10 iterrows
+    num_fake_rows = pytest.gen.randint(1, 10) # arbitrary, from 1 to 10
     for i in range(num_fake_rows):
         fake_row_values = []
         for j in range(pytest.gen.randint(1,10)): # arbitrary, from 1 to 10 row values
             fake_row_values.append(pytest.gen.randint(1, 10)) # arbitrary, from 1 to 10 as a value in row
-        fake_iterrows.append([i, fake_row_values])
+        fake_dataset.append([i, fake_row_values])
         expected_result_list.append(fake_row_values)
-    forced_return_iterrows = iter(fake_iterrows)
-    
-    expected_result = expected_result_list
 
-    mocker.patch(csv_parser.__name__ + '.pd.read_csv', return_value=fake_initial_data_set)
-    mocker.patch.object(fake_columns_str, 'contains', return_value=forced_return_contains)
-    mocker.patch.object(fake_loc, '__getitem__', return_value=fake_second_data_set)
-    mocker.patch.object(fake_second_data_set, 'iterrows', return_value=forced_return_iterrows)
+    mocker.patch(csv_parser.__name__ + '.open', return_value = fake_csv_file)
+    mocker.patch(csv_parser.__name__ + '.csv.reader', return_value = fake_dataset)
+    mocker.patch(csv_parser.__name__ + '.floatify_input', side_effect = expected_result_list)
 
     # Act
     result = pytest.cut.parse_csv_data(arg_dataFile)
 
     # Assert
-    assert csv_parser.pd.read_csv.call_count == 1
-    assert csv_parser.pd.read_csv.call_args_list[0].args == (arg_dataFile, )
-    assert csv_parser.pd.read_csv.call_args_list[0].kwargs == {'delimiter':',', 'header':0, 'dtype':str}
-    assert fake_columns_str.contains.call_count == 1
-    assert fake_columns_str.contains.call_args_list[0].args == ('^Unnamed', )
-    assert result == expected_result
+    assert csv_parser.open.call_count == 1
+    assert csv_parser.open.call_args_list[0].args == (arg_dataFile, 'r')
+    assert csv_parser.csv.reader.call_count == 1
+    assert csv_parser.csv.reader.call_args_list[0].args == (fake_csv_file, )
+    assert csv_parser.csv.reader.call_args_list[0].kwargs == ({'delimiter':','})
+    assert csv_parser.floatify_input.call_count == num_fake_rows
 
-def test_CSV_parse_csv_data_returns_list_of_data_frames_call_to_iterrows_returns_iterator_and_column_names_exist(mocker, setup_teardown):
-    # Arrange
-    arg_dataFile = MagicMock()
-
-    fake_initial_data_set = MagicMock()
-    fake_loc = MagicMock()
-    fake_initial_data_set.loc = fake_loc
-    fake_columns_str = MagicMock()
-    fake_columns = MagicMock()
-    fake_columns.str = fake_columns_str
-    fake_initial_data_set.columns = fake_columns
-    forced_return_contains = MagicMock()
-    fake_second_data_set = MagicMock()
-    fake_second_data_set.columns = MagicMock()
-    fake_second_data_set.columns.values = []
-    num_fake_columns = pytest.gen.randint(1,10) # arbitrary
-
-    fake_iterrows = []
-    expected_result_dict = []
-    num_fake_rows = pytest.gen.randint(1, 10) # arbitrary, from 1 to 10 iterrows
-    for i in range(num_fake_rows):
-        fake_row_values = []
-        for j in range(num_fake_columns):
-            fake_row_values.append(pytest.gen.randint(1, 10)) # arbitrary, from 1 to 10 as a value in row
-        fake_iterrows.append([fake_row_values, fake_row_values])
-        expected_result_dict.append(fake_row_values)
-    forced_return_iterrows = iter(fake_iterrows)
-    
-    expected_result = expected_result_dict
-
-    mocker.patch(csv_parser.__name__ + '.pd.read_csv', return_value=fake_initial_data_set)
-    mocker.patch.object(fake_columns_str, 'contains', return_value=forced_return_contains)
-    mocker.patch.object(fake_loc, '__getitem__', return_value=fake_second_data_set)
-    mocker.patch.object(fake_second_data_set, 'iterrows', return_value=forced_return_iterrows)
-
-    # Act
-    result = pytest.cut.parse_csv_data(arg_dataFile)
-
-    # Assert
-    assert csv_parser.pd.read_csv.call_count == 1
-    assert csv_parser.pd.read_csv.call_args_list[0].args == (arg_dataFile, )
-    assert csv_parser.pd.read_csv.call_args_list[0].kwargs == {'delimiter':',', 'header':0, 'dtype':str}
-    assert fake_columns_str.contains.call_count == 1
-    assert fake_columns_str.contains.call_args_list[0].args == ('^Unnamed', )
-    assert result == expected_result
+    assert result == expected_result_list
 
 # CSV parse_meta_data tests
 def test_CSV_parse_meta_data_file_returns_call_to_extract_meta_data_handle_ss_breakdown(mocker, setup_teardown):


### PR DESCRIPTION
Removes the need for Pandas by using the built in csv library.

Changed behavior when the timestamp is in mm:ss format: uses Jan 1, 2000 as the epoch instead of the current date. This will make testing easier as the timestamps will be the same no matter what day you ran your test.

Closes #89 