### PR TITLE
Removed requirement for mock package

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,7 +10,7 @@
 import pytest
 import random
 from time import time
-from mock import MagicMock
+from unittest.mock import MagicMock
 import sys
 
 def pytest_addoption(parser):

--- a/requirements_pip.txt
+++ b/requirements_pip.txt
@@ -1,5 +1,4 @@
 coverage==6.5.0
-mock==4.0.3
 numpy==1.23.4
 pytest==7.2.0
 pytest-mock==3.10.0

--- a/test/onair/data_handling/test_csv_parser.py
+++ b/test/onair/data_handling/test_csv_parser.py
@@ -9,7 +9,7 @@
 
 """ Test CSV Parser Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.data_handling.csv_parser as csv_parser
 from onair.data_handling.csv_parser import DataSource

--- a/test/onair/data_handling/test_on_air_data_source.py
+++ b/test/onair/data_handling/test_on_air_data_source.py
@@ -9,7 +9,7 @@
 
 """ Test OnAir Parser Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.data_handling.on_air_data_source as on_air_data_source
 from onair.data_handling.on_air_data_source import OnAirDataSource
@@ -88,7 +88,7 @@ def test_OnAirDataSource_raises_error_because_of_unimplemented_abstract_methods(
     # Act
     with pytest.raises(TypeError) as e_info:
         cut = OnAirDataSource.__new__(OnAirDataSource)
-    
+
     # Assert
     assert "Can't instantiate abstract class OnAirDataSource with" in e_info.__str__()
     assert "process_data_file" in e_info.__str__()
@@ -102,7 +102,7 @@ def test_OnAirDataSource_raises_error_when_an_inherited_class_is_instantiated_be
     # Act
     with pytest.raises(TypeError) as e_info:
         cut = IncompleteOnAirDataSource.__new__(IncompleteOnAirDataSource)
-    
+
     # Assert
     assert "Can't instantiate abstract class IncompleteOnAirDataSource with" in e_info.__str__()
     assert "process_data_file" in e_info.__str__()

--- a/test/onair/data_handling/test_parser_util.py
+++ b/test/onair/data_handling/test_parser_util.py
@@ -9,7 +9,7 @@
 
 """ Test Parser Util Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.data_handling.parser_util as parser_util
 
@@ -173,7 +173,7 @@ def test_parser_util_extract_meta_data_returns_expected_dicts_dict_when_len_conf
     forced_return_parse_tlm = {'subsystem_assignments' : fake_subsystem_assignments,
                                 'test_assignments' : fake_tests,
                                 'description_assignments' : fake_descs}
-    
+
     mocker.patch(parser_util.__name__ + '.parseTlmConfJson', return_value=forced_return_parse_tlm)
     mocker.patch(parser_util.__name__ + '.str2lst')
 
@@ -204,7 +204,7 @@ def test_parser_util_extract_meta_data_returns_expected_dicts_dict_when_len_conf
     noop_test_assign = 'NOOP'
     fake_tests = [[[fake_test_assign]]] * (len_configs - num_noops) + [[[noop_test_assign]]] * num_noops
     fake_descs = [MagicMock()] * len_configs
-    
+
     forced_return_parse_tlm = {'subsystem_assignments' : fake_subsystem_assignments,
                                 'test_assignments' : fake_tests,
                                 'description_assignments' : fake_descs}
@@ -355,7 +355,7 @@ def test_parser_util_flotify_input_raises_exception_when_float_returns_non_Value
 def test_parser_util_flotify_input_returns_list_of_size_one_that_contains_the_call_to_float_when_no_Exception_is_thrown_and_given__input_is_str(mocker):
     # Arrange
     arg__input = []
-    arg_remove_str = False 
+    arg_remove_str = False
 
     fake_item = str(MagicMock())
     arg__input.append(fake_item) # list of single str, one iteration
@@ -384,7 +384,7 @@ def test_parser_util_flotify_input_returns_list_of_size_one_that_contains_the_se
 
     mocker.patch(parser_util.__name__ + '.float', side_effect=[ValueError])
     mocker.patch(parser_util.__name__ + '.convert_str_to_timestamp', return_value=expected_result)
-    
+
     # Act
     result = parser_util.floatify_input(arg__input, arg_remove_str)
 
@@ -405,7 +405,7 @@ def test_parser_util_flotify_input_returns_list_of_size_one_that_contains_0_dot_
 
     mocker.patch(parser_util.__name__ + '.float', side_effect=[ValueError])
     mocker.patch(parser_util.__name__ + '.convert_str_to_timestamp', side_effect=[Exception])
-    
+
     # Act
     result = parser_util.floatify_input(arg__input, arg_remove_str)
 
@@ -425,7 +425,7 @@ def test_parser_util_flotify_input_default_arg_remove_str_is_False(mocker):
 
     mocker.patch(parser_util.__name__ + '.float', side_effect=[ValueError])
     mocker.patch(parser_util.__name__ + '.convert_str_to_timestamp', side_effect=[Exception])
-    
+
     # Act
     result = parser_util.floatify_input(arg__input)
 
@@ -442,7 +442,7 @@ def test_parser_util_flotify_input_returns_empty_list_when_two_Exceptions_are_th
 
     mocker.patch(parser_util.__name__ + '.float', side_effect=[ValueError])
     mocker.patch(parser_util.__name__ + '.convert_str_to_timestamp', side_effect=[Exception])
-    
+
     # Act
     result = parser_util.floatify_input(arg__input, arg_remove_str)
 
@@ -463,7 +463,7 @@ def test_parser_util_flotify_input_returns_call_to_float_that_was_given___input_
     expected_result = MagicMock()
 
     mocker.patch(parser_util.__name__ + '.float', return_value=expected_result)
-    
+
     # Act
     result = parser_util.floatify_input(arg__input)
 
@@ -510,13 +510,13 @@ def test_parser_util_flotify_input_returns_expected_values_for_given__input_that
 
     mocker.patch(parser_util.__name__ + '.float', side_effect=side_effects_for_float)
     mocker.patch(parser_util.__name__ + '.convert_str_to_timestamp', side_effect=side_effects_for_convert_str)
-    
+
     # Act
     result = parser_util.floatify_input(arg__input, arg_remove_str)
 
     # Assert
     assert result == expected_result
-    
+
 def test_parser_util_flotify_input_returns_expected_values_for_given__input_that_is_multi_typed_when_remove_str_is_False(mocker):
     # Arrange
     arg__input = []
@@ -558,7 +558,7 @@ def test_parser_util_flotify_input_returns_expected_values_for_given__input_that
 
     mocker.patch(parser_util.__name__ + '.float', side_effect=side_effects_for_float)
     mocker.patch(parser_util.__name__ + '.convert_str_to_timestamp', side_effect=side_effects_for_convert_str)
-    
+
     # Act
     result = parser_util.floatify_input(arg__input, arg_remove_str)
 
@@ -585,7 +585,7 @@ def test_parser_util_convert_str_to_timestamp_returns_datetime_strptime_timestam
     # Assert
     assert fake_dt_module.datetime.strptime.call_count == 1
     assert fake_dt_module.datetime.strptime.call_args_list[0].args == (arg_time_str, '%Y-%j-%H:%M:%S.%f')
-    assert fake_datetime.timestamp.call_count == 1 
+    assert fake_datetime.timestamp.call_count == 1
     assert result == fake_timestamp
 
 def test_parser_util_convert_str_to_timestamp_returns_datetime_timestamp_when_strptime_raises_error(mocker):

--- a/test/onair/data_handling/test_redis_adapter.py
+++ b/test/onair/data_handling/test_redis_adapter.py
@@ -7,7 +7,7 @@
 # Licensed under the NASA Open Source Agreement version 1.3
 # See "NOSA GSC-19165-1 OnAIR.pdf"
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.data_handling.redis_adapter as redis_adapter
 from onair.data_handling.redis_adapter import DataSource
@@ -57,7 +57,7 @@ def test_redis_adapter_DataSource__init__sets_redis_values_then_connects_and_sub
     assert cut.connect.call_args_list[0].args == ()
     assert cut.subscribe.call_count == 1
     assert cut.subscribe.call_args_list[0].args == (expected_subscriptions, )
-    
+
 # connect tests
 def test_redis_adapter_DataSource_connect_establishes_server_with_initialized_attributes(mocker):
     # Arrange
@@ -65,12 +65,12 @@ def test_redis_adapter_DataSource_connect_establishes_server_with_initialized_at
     expected_port = MagicMock()
     expected_db = MagicMock()
     fake_server = MagicMock()
-    
+
     cut = DataSource.__new__(DataSource)
     cut.address = expected_address
     cut.port = expected_port
     cut.db = expected_db
-    
+
     mocker.patch(redis_adapter.__name__ + '.print_msg')
     mocker.patch('redis.Redis', return_value=fake_server)
 
@@ -92,7 +92,7 @@ def test_redis_adapter_DataSource_fails_to_connect_to_server(mocker):
     expected_port = MagicMock()
     expected_db = MagicMock()
     fake_server = MagicMock()
-    
+
     cut = DataSource.__new__(DataSource)
     cut.address = expected_address
     cut.port = expected_port
@@ -277,7 +277,7 @@ def test_redis_adapter_DataSource_get_next_when_called_multiple_times_when_new_d
     for i in range(num_calls):
         results[i] = expected_data[i]
     assert cut.double_buffer_read_index == (num_calls + pre_call_index) % 2
-    
+
 def test_redis_adapter_DataSource_get_next_waits_until_data_is_available(mocker):
     # Arrange
     # Renew DataSource to ensure test independence

--- a/test/onair/data_handling/test_tlm_json_parser.py
+++ b/test/onair/data_handling/test_tlm_json_parser.py
@@ -9,7 +9,7 @@
 
 """ Test TLM Json Parser Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.data_handling.tlm_json_parser as tlm_json_parser
 
@@ -235,7 +235,7 @@ def test_tlm_json_parser_parseTlmConfJson_returns_expected_configs_dict_when_reo
     ordering_list = []
     for label in fake_label:
         ordering_list.append(desired_order[label])
-    
+
     ordered_subsys = [y for x, y in sorted(zip(ordering_list, fake_subsystem))]
     ordered_mnemonics = [y for x, y in sorted(zip(ordering_list, fake_mnemonics))]
     ordered_limits = [y for x, y in sorted(zip(ordering_list, fake_limits))]
@@ -298,13 +298,13 @@ def test_tlm_json_parser_parseTlmConfJson_returns_expected_configs_dict_when_reo
     ordering_list = []
     for label in fake_label:
         ordering_list.append(desired_order[label])
-    
+
     ordered_subsys = [y for x, y in sorted(zip(ordering_list, fake_subsystem))]
     ordered_mnemonics = [y for x, y in sorted(zip(ordering_list, fake_mnemonics))]
     ordered_limits = [y for x, y in sorted(zip(ordering_list, fake_limits))]
     ordered_descs = [y for x, y in sorted(zip(ordering_list, fake_description))]
     ordered_labels = [y for x, y in sorted(zip(ordering_list, fake_label))]
-    
+
     fake_organized_data = {}
     for i in range(num_elems):
         fake_organized_data[fake_label[i]] = {'subsystem' : fake_subsystem[i],
@@ -405,7 +405,7 @@ def test_tlm_json_parser_str2lst_returns_call_to_ast_literal_eval_which_receive_
     arg_string = str(MagicMock())
 
     expected_result = MagicMock()
-    
+
     mocker.patch(tlm_json_parser.__name__ + '.ast.literal_eval', return_value=expected_result)
 
     # Act
@@ -419,10 +419,10 @@ def test_tlm_json_parser_str2lst_returns_call_to_ast_literal_eval_which_receive_
 def test_tlm_json_parser_str2lst_prints_message_when_ast_literal_eval_receives_given_string_but_raises_exception(mocker):
     # Arrange
     arg_string = str(MagicMock())
-    
+
     mocker.patch(tlm_json_parser.__name__ + '.ast.literal_eval', side_effect=Exception)
     mocker.patch(tlm_json_parser.__name__ + '.print')
-    
+
     # Act
     result = tlm_json_parser.str2lst(arg_string)
 
@@ -449,7 +449,7 @@ def test_tlm_json_parser_parseJson_opens_given_path_and_returns_data_returned_by
 
     # Act
     result = tlm_json_parser.parseJson(arg_path)
-    
+
     # Assert
     assert tlm_json_parser.open.call_count == 1
     assert tlm_json_parser.open.call_args_list[0].args == (arg_path, 'rb')

--- a/test/onair/src/ai_components/ai_plugin_abstract/test_AI_plugin_core.py
+++ b/test/onair/src/ai_components/ai_plugin_abstract/test_AI_plugin_core.py
@@ -9,7 +9,7 @@
 
 """ Test Generic Component Core (abstract class) Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.src.ai_components.ai_plugin_abstract.ai_plugin as ai_plugin
 from onair.src.ai_components.ai_plugin_abstract.ai_plugin import AIPlugin

--- a/test/onair/src/ai_components/test_learners_interface.py
+++ b/test/onair/src/ai_components/test_learners_interface.py
@@ -9,7 +9,7 @@
 
 """ Test LearnersInterface Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.src.ai_components.learners_interface as learners_interface
 from onair.src.ai_components.learners_interface import LearnersInterface

--- a/test/onair/src/ai_components/test_planners_interface.py
+++ b/test/onair/src/ai_components/test_planners_interface.py
@@ -9,7 +9,7 @@
 
 """ Test PlannersInterface Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.src.ai_components.planners_interface as planners_interface
 from onair.src.ai_components.planners_interface import PlannersInterface
@@ -40,7 +40,7 @@ def test_PlannersInterface__init__sets_self_headers_to_given_headers_and_sets_se
     forced_return_ai_constructs = MagicMock()
 
     mocker.patch(planners_interface.__name__ + '.import_plugins', return_value=forced_return_ai_constructs)
-    
+
     cut = PlannersInterface.__new__(PlannersInterface)
 
     # Act
@@ -80,7 +80,7 @@ def test_check_for_salient_event_does_nothing():
 def test_render_reasoning_does_nothing():
     # Arrange
     cut = PlannersInterface.__new__(PlannersInterface)
-    
+
     # Act
     result = cut.render_reasoning()
 

--- a/test/onair/src/reasoning/test_agent.py
+++ b/test/onair/src/reasoning/test_agent.py
@@ -9,7 +9,7 @@
 
 """ Test Agent Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.src.reasoning.agent as agent
 from onair.src.reasoning.agent import Agent
@@ -95,7 +95,7 @@ def test_Agent_reason_updates_vehicle_rep_with_given_frame_and_updates_learning_
     fake_complex_reasoning_systems = MagicMock()
     fake_learning_systems_reasoning = MagicMock()
     fake_planning_systems_reasoning = MagicMock()
-    expected_aggregate_high_level_info = {'vehicle_rep': fake_state, 
+    expected_aggregate_high_level_info = {'vehicle_rep': fake_state,
                                           'learning_systems':fake_learning_systems_reasoning,
                                           'planning_systems':fake_planning_systems_reasoning}
     expected_result = MagicMock()
@@ -138,7 +138,7 @@ def test_Agent_reason_updates_vehicle_rep_with_given_frame_and_updates_learning_
     assert cut.planning_systems.render_reasoning.call_count == 1
     assert cut.planning_systems.render_reasoning.call_args_list[0].args == ()
 
-     
+
 # diagnose tests
 def test_Agent_diagnose_returns_empty_Dict():
     # Arrange

--- a/test/onair/src/reasoning/test_complex_resoning_interface.py
+++ b/test/onair/src/reasoning/test_complex_resoning_interface.py
@@ -9,7 +9,7 @@
 
 """ Test PlannersInterface Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.src.reasoning.complex_reasoning_interface as complex_reasoning_interface
 from onair.src.reasoning.complex_reasoning_interface import ComplexReasoningInterface
@@ -40,7 +40,7 @@ def test_ComplexReasoningInterface__init__sets_self_headers_to_given_headers_and
     forced_return_reasoning_constructs = MagicMock()
 
     mocker.patch(complex_reasoning_interface.__name__ + '.import_plugins', return_value=forced_return_reasoning_constructs)
-    
+
 
     cut = ComplexReasoningInterface.__new__(ComplexReasoningInterface)
 

--- a/test/onair/src/reasoning/test_diagnosis.py
+++ b/test/onair/src/reasoning/test_diagnosis.py
@@ -9,7 +9,7 @@
 
 """ Test Diagnosis Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.src.reasoning.diagnosis as diagnosis
 from onair.src.reasoning.diagnosis import Diagnosis
@@ -204,7 +204,7 @@ def test_Diagnosis_walkdown_returns_NO_DIAGNOSIS_when_mnemonic_name_is_not_blank
     fake_kalman_results = [MagicMock()] * pytest.gen.randint(1, 10) # arbitrary, random int from 1 to 10
     len_fake_list = pytest.gen.randint(1, 10) # arbitrary, random int from 1 to 10
     fake_kalman_results[0] = [MagicMock()] * len_fake_list
-    
+
     rand_name_index = pytest.gen.randint(0, len_fake_list - 1) # random index in fake_kalman_results[0]
     fake_kalman_results[0][rand_name_index] = arg_mnemonic_name
 

--- a/test/onair/src/run_scripts/test_execution_engine.py
+++ b/test/onair/src/run_scripts/test_execution_engine.py
@@ -9,7 +9,7 @@
 
 """ Test Execution Engine Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.src.run_scripts.execution_engine as execution_engine
 from onair.src.run_scripts.execution_engine import ExecutionEngine

--- a/test/onair/src/run_scripts/test_sim.py
+++ b/test/onair/src/run_scripts/test_sim.py
@@ -9,7 +9,7 @@
 
 """ Test Simulator Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.src.run_scripts.sim as sim
 from onair.src.run_scripts.sim import Simulator

--- a/test/onair/src/systems/test_status.py
+++ b/test/onair/src/systems/test_status.py
@@ -9,7 +9,7 @@
 
 """ Test Status Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from onair.src.systems.status import Status
 
@@ -106,9 +106,9 @@ def test_Status_set_status_when_only_stat_arg_is_provided_sets_variables_to_expe
 def test_Status_set_status_raises_error_because_bayesian_conf_greater_than_1():
     # Arrange
     cut = Status.__new__(Status)
-    
+
     arg_status = '---'
-    arg_bayesian_conf = pytest.gen.uniform(1.01, 10.0) # arbitrary float greater than 1.0 (top of accepted range) 
+    arg_bayesian_conf = pytest.gen.uniform(1.01, 10.0) # arbitrary float greater than 1.0 (top of accepted range)
 
     # Act
     with pytest.raises(AssertionError) as e_info:
@@ -120,7 +120,7 @@ def test_Status_set_status_raises_error_because_bayesian_conf_greater_than_1():
 def test_Status_set_status_raises_error_because_bayesian_conf_less_than_neg_1():
     # Arrange
     cut = Status.__new__(Status)
-    
+
     arg_status = '---'
     arg_bayesian_conf = pytest.gen.uniform(-10.0, -1.01) # arbitrary float less than -1.0 (bottom of accepted range)
 

--- a/test/onair/src/systems/test_telemetry_test_suite.py
+++ b/test/onair/src/systems/test_telemetry_test_suite.py
@@ -6,10 +6,10 @@
 #
 # Licensed under the NASA Open Source Agreement version 1.3
 # See "NOSA GSC-19165-1 OnAIR.pdf"
-  
+
 """ Test Status Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.src.systems.telemetry_test_suite as telemetry_test_suite
 from onair.src.systems.telemetry_test_suite import TelemetryTestSuite
@@ -31,7 +31,7 @@ def test_TelemetryTestSuite__init__sets_the_expected_values_with_given_headers_a
     assert cut.latest_results == None
     assert cut.epsilon == 1/100000 # production codes notes this value as needing intelligent definition
     assert cut.all_tests == {'STATE' : cut.state,
-                      'FEASIBILITY' : cut.feasibility, 
+                      'FEASIBILITY' : cut.feasibility,
                              'NOOP' : cut.noop}
 
 def test_TelemetryTestSuite__init__default_arg_tests_is_empty_list(mocker):
@@ -158,14 +158,14 @@ def test_TelemetryTestSuite_run_tests_return_Status_object_based_upon_given_head
     cut.tests = {arg_header_index:fake_tests}
     cut.dataFields = {arg_header_index:expected_datafield}
     cut.epsilon = MagicMock()
-    
+
     # IMPORTANT: note, using state function as an easy mock -- not really calling it here!!
     mocker.patch.object(cut, 'state', return_value=(fake_stat, fake_mass_assigments))
     mocker.patch.object(cut, 'calc_single_status', return_value=fake_bayesian)
     mocker.patch(telemetry_test_suite.__name__ + '.Status', return_value = expected_result)
 
     cut.all_tests = {fake_tests[0][0]:cut.state} # IMPORTANT: purposely set AFTER patch of cut's sync function
-    
+
     # Act
     result = cut.run_tests(arg_header_index, arg_test_val, arg_sync_data)
 
@@ -191,7 +191,7 @@ def test_TelemetryTestSuite_run_tests_return_Status_object_based_upon_given_head
     fake_stat = MagicMock()
     fake_mass_assigments = MagicMock()
     fake_bayesian = [MagicMock(),MagicMock()]
-    
+
     expected_datafield = MagicMock()
     expected_result = telemetry_test_suite.Status.__new__(telemetry_test_suite.Status)
     expected_stats = []
@@ -202,13 +202,13 @@ def test_TelemetryTestSuite_run_tests_return_Status_object_based_upon_given_head
     cut.tests = {arg_header_index:fake_tests}
     cut.dataFields = {arg_header_index:expected_datafield}
     cut.epsilon = MagicMock()
-    
+
     mocker.patch.object(cut, 'state', return_value=(fake_stat, fake_mass_assigments))
     mocker.patch.object(cut, 'calc_single_status', return_value=fake_bayesian)
     mocker.patch(telemetry_test_suite.__name__ + '.Status', return_value = expected_result)
 
     cut.all_tests = {'STATE':cut.state} # IMPORTANT: purposely set AFTER patch of cut's state function
-    
+
     # setup random input and results
     for i in range(num_fake_tests):
         fake_vars.append(MagicMock())
@@ -228,7 +228,7 @@ def test_TelemetryTestSuite_run_tests_return_Status_object_based_upon_given_head
     assert telemetry_test_suite.Status.call_count == 1
     assert telemetry_test_suite.Status.call_args_list[0].args == (expected_datafield, fake_bayesian[0], fake_bayesian[1])
     assert result == expected_result
-  
+
 # get_latest_result tests
 def test_TelemetryTestSuite_get_latest_results_returns_None_when_latest_results_is_None():
     # Arrange
@@ -272,8 +272,8 @@ def test_TelemetryTestSuite_state_returns_tuple_of_str_GREEN_and_list_containing
     factor = 1
     if pytest.gen.randint(0,1) == 1:
         factor *= -1
-     # arbitrary, from 0 to 200 with 50/50 change of negative 
-    fake_mid_point = pytest.gen.randint(0, 200) * factor # arbitrary, from 0 to 200 with 50/50 change of negative 
+     # arbitrary, from 0 to 200 with 50/50 change of negative
+    fake_mid_point = pytest.gen.randint(0, 200) * factor # arbitrary, from 0 to 200 with 50/50 change of negative
     fake_green_tol = pytest.gen.randint(1, 50) # arbitrary, from 1 to 50 allowance in both directions from fake_mid_point
 
     arg_test_params.append(range((fake_mid_point - fake_green_tol), (fake_mid_point + fake_green_tol)))
@@ -302,8 +302,8 @@ def test_TelemetryTestSuite_state_returns_tuple_of_str_YELLOW_and_list_containin
     factor = 1
     if pytest.gen.randint(0,1) == 1:
         factor *= -1
-     # arbitrary, from 0 to 200 with 50/50 change of negative 
-    fake_mid_point = pytest.gen.randint(0, 200) * factor # arbitrary, from 0 to 200 with 50/50 change of negative 
+     # arbitrary, from 0 to 200 with 50/50 change of negative
+    fake_mid_point = pytest.gen.randint(0, 200) * factor # arbitrary, from 0 to 200 with 50/50 change of negative
     fake_green_tol = pytest.gen.randint(1, 50) # arbitrary, from 1 to 50 allowance in both directions from fake_mid_point
     fake_yellow_tol = pytest.gen.randint(1, 20) + fake_green_tol # arbitrary, from 1 to 20 allowance in both directions from fake_mid_point + fake_green_tol
 
@@ -311,15 +311,15 @@ def test_TelemetryTestSuite_state_returns_tuple_of_str_YELLOW_and_list_containin
     arg_test_params.append(range((fake_mid_point - fake_yellow_tol), (fake_mid_point + fake_yellow_tol)))
     arg_test_params.append(MagicMock())
 
-    if pytest.gen.randint(0,1) == 1: 
+    if pytest.gen.randint(0,1) == 1:
         arg_val = pytest.gen.randint(fake_green_tol, fake_yellow_tol - 1) + fake_mid_point # random val within upper yellow range
     else:
-        arg_val = pytest.gen.randint(0 - fake_yellow_tol, 0 - fake_green_tol - 1) + fake_mid_point # sometimes flip to lower yellow range   
+        arg_val = pytest.gen.randint(0 - fake_yellow_tol, 0 - fake_green_tol - 1) + fake_mid_point # sometimes flip to lower yellow range
     if arg_val > 0:
         arg_val += pytest.gen.random() # make float by adding some random decimal
     else:
         arg_val -= pytest.gen.random() # make float by adding some random decimal
-    
+
     cut = TelemetryTestSuite.__new__(TelemetryTestSuite)
 
     # Act
@@ -327,7 +327,7 @@ def test_TelemetryTestSuite_state_returns_tuple_of_str_YELLOW_and_list_containin
 
     # Assert
     assert result == ('YELLOW', [({'YELLOW'}, 1.0)])
-    
+
 def test_TelemetryTestSuite_state_returns_tuple_of_str_RED_and_list_containing_tuple_of_set_of_str_RED_and_1_pt_0_when_int_val_is_in_range_test_params_2_and_not_in_0_or_1():
     # Arrange
     arg_test_params = []
@@ -336,8 +336,8 @@ def test_TelemetryTestSuite_state_returns_tuple_of_str_RED_and_list_containing_t
     factor = 1
     if pytest.gen.randint(0,1) == 1:
         factor *= -1
-     # arbitrary, from 0 to 200 with 50/50 change of negative 
-    fake_mid_point = pytest.gen.randint(0, 200) * factor # arbitrary, from 0 to 200 with 50/50 change of negative 
+     # arbitrary, from 0 to 200 with 50/50 change of negative
+    fake_mid_point = pytest.gen.randint(0, 200) * factor # arbitrary, from 0 to 200 with 50/50 change of negative
     fake_green_tol = pytest.gen.randint(1, 50) # arbitrary, from 1 to 50 allowance in both directions from fake_mid_point
     fake_yellow_tol = pytest.gen.randint(1, 20) + fake_green_tol # arbitrary, from 1 to 20 allowance in both directions from fake_mid_point + fake_green_tol
     fake_red_tol = pytest.gen.randint(1, 10) + fake_yellow_tol # arbitrary, from 1 to 10 allowance in both directions from fake_mid_point + fake_yellow_tol
@@ -346,15 +346,15 @@ def test_TelemetryTestSuite_state_returns_tuple_of_str_RED_and_list_containing_t
     arg_test_params.append(range((fake_mid_point - fake_yellow_tol), (fake_mid_point + fake_yellow_tol)))
     arg_test_params.append(range((fake_mid_point - fake_red_tol), (fake_mid_point + fake_red_tol)))
 
-    if pytest.gen.randint(0,1) == 1: 
+    if pytest.gen.randint(0,1) == 1:
         arg_val = pytest.gen.randint(fake_yellow_tol, fake_red_tol - 1) + fake_mid_point # random val within upper red range
     else:
-        arg_val = pytest.gen.randint(0 - fake_red_tol, 0 - fake_yellow_tol - 1) + fake_mid_point # sometimes flip to lower red range   
+        arg_val = pytest.gen.randint(0 - fake_red_tol, 0 - fake_yellow_tol - 1) + fake_mid_point # sometimes flip to lower red range
     if arg_val > 0:
         arg_val += pytest.gen.random() # make float by adding some random decimal
     else:
         arg_val -= pytest.gen.random() # make float by adding some random decimal
-    
+
     cut = TelemetryTestSuite.__new__(TelemetryTestSuite)
 
     # Act
@@ -362,7 +362,7 @@ def test_TelemetryTestSuite_state_returns_tuple_of_str_RED_and_list_containing_t
 
     # Assert
     assert result == ('RED', [({'RED'}, 1.0)])
-     
+
 def test_TelemetryTestSuite_state_returns_tuple_of_str_3_dashes_and_list_containing_tuple_of_set_of_str_RED_YELLOW_and_GREEN_and_1_pt_0_when_int_val_is_in_not_in_any_range():
     # Arrange
     arg_test_params = []
@@ -371,8 +371,8 @@ def test_TelemetryTestSuite_state_returns_tuple_of_str_3_dashes_and_list_contain
     factor = 1
     if pytest.gen.randint(0,1) == 1:
         factor *= -1
-     # arbitrary, from 0 to 200 with 50/50 change of negative 
-    fake_mid_point = pytest.gen.randint(0, 200) * factor # arbitrary, from 0 to 200 with 50/50 change of negative 
+     # arbitrary, from 0 to 200 with 50/50 change of negative
+    fake_mid_point = pytest.gen.randint(0, 200) * factor # arbitrary, from 0 to 200 with 50/50 change of negative
     fake_green_tol = pytest.gen.randint(1, 50) # arbitrary, from 1 to 50 allowance in both directions from fake_mid_point
     fake_yellow_tol = pytest.gen.randint(1, 20) + fake_green_tol # arbitrary, from 1 to 20 allowance in both directions from fake_mid_point + fake_green_tol
     fake_red_tol = pytest.gen.randint(1, 10) + fake_yellow_tol # arbitrary, from 1 to 10 allowance in both directions from fake_mid_point + fake_yellow_tol
@@ -381,15 +381,15 @@ def test_TelemetryTestSuite_state_returns_tuple_of_str_3_dashes_and_list_contain
     arg_test_params.append(range((fake_mid_point - fake_yellow_tol), (fake_mid_point + fake_yellow_tol)))
     arg_test_params.append(range((fake_mid_point - fake_red_tol), (fake_mid_point + fake_red_tol)))
 
-    if pytest.gen.randint(0,1) == 1: 
+    if pytest.gen.randint(0,1) == 1:
         arg_val = fake_red_tol + fake_mid_point + 1 # random val outside upper red
     else:
-        arg_val = 0 - fake_red_tol + fake_mid_point - 1 # random val outside lower red  
+        arg_val = 0 - fake_red_tol + fake_mid_point - 1 # random val outside lower red
     if arg_val > 0:
         arg_val += pytest.gen.random() # make float by adding some random decimal
     else:
         arg_val -= pytest.gen.random() # make float by adding some random decimal
-    
+
     cut = TelemetryTestSuite.__new__(TelemetryTestSuite)
 
     # Act
@@ -397,7 +397,7 @@ def test_TelemetryTestSuite_state_returns_tuple_of_str_3_dashes_and_list_contain
 
     # Assert
     assert result == ('---', [({'RED', 'YELLOW', 'GREEN'}, 1.0)])
-    
+
 # feasibility tests
 def test_TelemetryTestSuite_feasibility_asserts_len_given_test_params_is_not_2_or_4(mocker):
     # Arrange
@@ -425,9 +425,9 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
 
     fake_lowest_bound = pytest.gen.randint(-100, 100) # arbitrary, from -100 to 100
     fake_highest_bound = fake_lowest_bound + pytest.gen.randint(10, 100) # arbitrary, from 10 to 100 higher than lowest bound
-    
-    arg_test_params = [fake_lowest_bound, fake_highest_bound]    
-    arg_val = fake_lowest_bound    
+
+    arg_test_params = [fake_lowest_bound, fake_highest_bound]
+    arg_val = fake_lowest_bound
 
     cut = TelemetryTestSuite.__new__(TelemetryTestSuite)
 
@@ -443,13 +443,13 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
 
     fake_lowest_bound = pytest.gen.randint(-100, 100) # arbitrary, from -100 to 100
     fake_highest_bound = fake_lowest_bound + pytest.gen.randint(10, 100) # arbitrary, from 10 to 100 higher than lowest bound
-    
-    arg_test_params = [fake_lowest_bound, 
-                       fake_lowest_bound + 1, 
-                       fake_highest_bound - 1, 
-                       fake_highest_bound]    
-    
-    arg_val = fake_lowest_bound    
+
+    arg_test_params = [fake_lowest_bound,
+                       fake_lowest_bound + 1,
+                       fake_highest_bound - 1,
+                       fake_highest_bound]
+
+    arg_val = fake_lowest_bound
 
     cut = TelemetryTestSuite.__new__(TelemetryTestSuite)
 
@@ -468,9 +468,9 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
     fake_delta = arg_epsilon * abs(fake_highest_bound - fake_lowest_bound)
 
     arg_test_params = [fake_lowest_bound,
-                       fake_highest_bound]    
-    
-    arg_val = fake_lowest_bound - fake_delta - 1 # -1 for less than low minus delta  
+                       fake_highest_bound]
+
+    arg_val = fake_lowest_bound - fake_delta - 1 # -1 for less than low minus delta
 
     cut = TelemetryTestSuite.__new__(TelemetryTestSuite)
 
@@ -489,9 +489,9 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
     fake_delta = arg_epsilon * abs(fake_highest_bound - fake_lowest_bound)
 
     arg_test_params = [fake_lowest_bound,
-                       fake_highest_bound]    
-    
-    arg_val = fake_lowest_bound - fake_delta - 1 # -1 for less than low minus delta  
+                       fake_highest_bound]
+
+    arg_val = fake_lowest_bound - fake_delta - 1 # -1 for less than low minus delta
 
     cut = TelemetryTestSuite.__new__(TelemetryTestSuite)
 
@@ -510,8 +510,8 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
     fake_delta = arg_epsilon * abs(fake_highest_bound - fake_lowest_bound)
 
     arg_test_params = [fake_lowest_bound,
-                       fake_highest_bound]    
-    arg_val = fake_lowest_bound - 1   
+                       fake_highest_bound]
+    arg_val = fake_lowest_bound - 1
 
     expected_mass = abs(fake_lowest_bound - arg_val)/fake_delta
     expected_red_yellow_mass = 1.0 - expected_mass
@@ -535,8 +535,8 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
     arg_test_params = [fake_lowest_bound,
                        fake_lowest_bound + 2,
                        fake_highest_bound - 2,
-                       fake_highest_bound]    
-    arg_val = fake_lowest_bound - 1   
+                       fake_highest_bound]
+    arg_val = fake_lowest_bound - 1
 
     expected_mass = abs(fake_lowest_bound - arg_val)/fake_delta
     expected_red_yellow_mass = 1.0 - expected_mass
@@ -555,9 +555,9 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
 
     fake_lowest_bound = pytest.gen.randint(-100, 100) # arbitrary, from -100 to 100
     fake_highest_bound = fake_lowest_bound + pytest.gen.randint(10, 100) # arbitrary, from 10 to 100 higher than lowest bound
-    
-    arg_test_params = [fake_lowest_bound, fake_highest_bound]    
-    arg_val = fake_highest_bound    
+
+    arg_test_params = [fake_lowest_bound, fake_highest_bound]
+    arg_val = fake_highest_bound
 
     cut = TelemetryTestSuite.__new__(TelemetryTestSuite)
 
@@ -573,13 +573,13 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
 
     fake_lowest_bound = pytest.gen.randint(-100, 100) # arbitrary, from -100 to 100
     fake_highest_bound = fake_lowest_bound + pytest.gen.randint(10, 100) # arbitrary, from 10 to 100 higher than lowest bound
-    
-    arg_test_params = [fake_lowest_bound, 
-                       fake_lowest_bound + 1, 
-                       fake_highest_bound - 1, 
-                       fake_highest_bound]    
-    
-    arg_val = fake_highest_bound    
+
+    arg_test_params = [fake_lowest_bound,
+                       fake_lowest_bound + 1,
+                       fake_highest_bound - 1,
+                       fake_highest_bound]
+
+    arg_val = fake_highest_bound
 
     cut = TelemetryTestSuite.__new__(TelemetryTestSuite)
 
@@ -598,9 +598,9 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
     fake_delta = arg_epsilon * abs(fake_highest_bound - fake_lowest_bound)
 
     arg_test_params = [fake_lowest_bound,
-                       fake_highest_bound]    
-    
-    arg_val = fake_highest_bound + fake_delta + 1 # +1 for more than high plus delta  
+                       fake_highest_bound]
+
+    arg_val = fake_highest_bound + fake_delta + 1 # +1 for more than high plus delta
 
     cut = TelemetryTestSuite.__new__(TelemetryTestSuite)
 
@@ -619,9 +619,9 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
     fake_delta = arg_epsilon * abs(fake_highest_bound - fake_lowest_bound)
 
     arg_test_params = [fake_lowest_bound,
-                       fake_highest_bound]    
-    
-    arg_val = fake_highest_bound + fake_delta + 1 # +1 for more than high plus delta  
+                       fake_highest_bound]
+
+    arg_val = fake_highest_bound + fake_delta + 1 # +1 for more than high plus delta
 
     cut = TelemetryTestSuite.__new__(TelemetryTestSuite)
 
@@ -640,8 +640,8 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
     fake_delta = arg_epsilon * abs(fake_highest_bound - fake_lowest_bound)
 
     arg_test_params = [fake_lowest_bound,
-                       fake_highest_bound]    
-    arg_val = fake_highest_bound + 1   
+                       fake_highest_bound]
+    arg_val = fake_highest_bound + 1
 
     expected_mass = abs(fake_highest_bound - arg_val)/fake_delta
     expected_red_yellow_mass = 1.0 - expected_mass
@@ -665,8 +665,8 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
     arg_test_params = [fake_lowest_bound,
                        fake_lowest_bound + 2,
                        fake_highest_bound - 2,
-                       fake_highest_bound]    
-    arg_val = fake_highest_bound + 1   
+                       fake_highest_bound]
+    arg_val = fake_highest_bound + 1
 
     expected_mass = abs(fake_highest_bound - arg_val)/fake_delta
     expected_red_yellow_mass = 1.0 - expected_mass
@@ -685,14 +685,14 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
 
     fake_lowest_bound = pytest.gen.randint(-100, 100) # arbitrary, from -100 to 100
     fake_highest_bound = fake_lowest_bound + pytest.gen.randint(10, 100) # arbitrary, from 10 to 100 higher than lowest bound
-    
-    arg_test_params = [fake_lowest_bound, fake_highest_bound]    
-    arg_val = int(fake_highest_bound - (abs(fake_highest_bound - fake_lowest_bound) / 2))  
+
+    arg_test_params = [fake_lowest_bound, fake_highest_bound]
+    arg_val = int(fake_highest_bound - (abs(fake_highest_bound - fake_lowest_bound) / 2))
 
     fake_delta = arg_epsilon * (abs(fake_highest_bound-fake_lowest_bound))
     expected_mass = abs(fake_lowest_bound - arg_val)/fake_delta
     print(fake_lowest_bound, arg_val, fake_highest_bound)
-    
+
     cut = TelemetryTestSuite.__new__(TelemetryTestSuite)
 
     # Act
@@ -707,17 +707,17 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
 
     fake_lowest_bound = pytest.gen.randint(-100, 100) # arbitrary, from -100 to 100
     fake_highest_bound = fake_lowest_bound + pytest.gen.randint(10, 100) # arbitrary, from 3 to 100 higher than lowest bound
-    
-    arg_test_params = [fake_lowest_bound, 
+
+    arg_test_params = [fake_lowest_bound,
                        fake_lowest_bound + 1,
                        fake_highest_bound - 1,
-                       fake_highest_bound]    
+                       fake_highest_bound]
 
     fake_delta = arg_epsilon * (abs(fake_highest_bound-fake_lowest_bound))
-     
-    arg_val = int(fake_highest_bound - (abs(fake_highest_bound - fake_lowest_bound) / 2))  
+
+    arg_val = int(fake_highest_bound - (abs(fake_highest_bound - fake_lowest_bound) / 2))
     print(fake_lowest_bound, arg_val, fake_lowest_bound + 2, fake_highest_bound -2, fake_highest_bound)
-    
+
     cut = TelemetryTestSuite.__new__(TelemetryTestSuite)
 
     # Act
@@ -732,17 +732,17 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
 
     fake_lowest_bound = pytest.gen.randint(-100, 100) # arbitrary, from -100 to 100
     fake_highest_bound = fake_lowest_bound + pytest.gen.randint(10, 100) # arbitrary, from 10 to 100 higher than lowest bound
-    
-    arg_test_params = [fake_lowest_bound, 
+
+    arg_test_params = [fake_lowest_bound,
                        fake_lowest_bound + 2,
                        fake_highest_bound - 2,
-                       fake_highest_bound]    
+                       fake_highest_bound]
 
     fake_delta = arg_epsilon * (abs(fake_highest_bound-fake_lowest_bound))
-     
+
     arg_val = fake_lowest_bound + 1
     print(fake_lowest_bound, arg_val, fake_lowest_bound + 2, fake_highest_bound -2, fake_highest_bound)
-    
+
     cut = TelemetryTestSuite.__new__(TelemetryTestSuite)
 
     # Act
@@ -757,11 +757,11 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
 
     fake_lowest_bound = pytest.gen.randint(-100, 100) # arbitrary, from -100 to 100
     fake_highest_bound = fake_lowest_bound + pytest.gen.randint(20, 100) # arbitrary, from 10 to 100 higher than lowest bound
-    
-    arg_test_params = [fake_lowest_bound, 
+
+    arg_test_params = [fake_lowest_bound,
                        fake_lowest_bound + 4,
                        fake_highest_bound - 4,
-                       fake_highest_bound]    
+                       fake_highest_bound]
 
     arg_val = fake_highest_bound - 1
     print(fake_lowest_bound, fake_lowest_bound + 4, fake_highest_bound -4, arg_val, fake_highest_bound)
@@ -779,11 +779,11 @@ def test_TelemetryTestSuite_feasibility_return_expected_stat_and_mass_assignment
 
     fake_lowest_bound = pytest.gen.randint(-100, 100) # arbitrary, from -100 to 100
     fake_highest_bound = fake_lowest_bound + pytest.gen.randint(20, 100) # arbitrary, from 10 to 100 higher than lowest bound
-    
-    arg_test_params = [fake_lowest_bound, 
+
+    arg_test_params = [fake_lowest_bound,
                        fake_lowest_bound + 4,
                        fake_highest_bound - 4,
-                       fake_highest_bound]    
+                       fake_highest_bound]
 
     arg_val = fake_highest_bound - 4
     print(fake_lowest_bound, fake_lowest_bound + 4, fake_highest_bound -4, arg_val, fake_highest_bound)
@@ -823,7 +823,7 @@ def test_TelemetryTestSuite_calc_single_status_returns_tuple_of_value_from_call_
 
     mocker.patch(telemetry_test_suite.__name__ + '.Counter', return_value=fake_occurrences)
     mocker.patch.object(fake_occurrences, 'most_common', return_value=[[fake_max_occurrence]])
-    
+
     # Act
     result = cut.calc_single_status(arg_status_list, arg_mode)
 
@@ -844,7 +844,7 @@ def test_TelemetryTestSuite_calc_single_status_returns_tuple_of_value_from_call_
 
     mocker.patch(telemetry_test_suite.__name__ + '.Counter', return_value=fake_occurrences)
     mocker.patch.object(fake_occurrences, 'most_common', return_value=[[fake_max_occurrence]])
-    
+
     # Act
     result = cut.calc_single_status(arg_status_list, arg_mode)
 
@@ -860,7 +860,7 @@ def test_TelemetryTestSuite_calc_single_status_returns_tuple_of_value_from_call_
 
     num_fake_statuses = pytest.gen.randint(1, 10) # arbitrary, from 1 to 10 (0 not allowed, div by 0 error)
     fake_max_occurrence = MagicMock()
-    
+
     for i in range(num_fake_statuses):
         arg_status_list.append(MagicMock())
     fake_occurrences = telemetry_test_suite.Counter.__new__(telemetry_test_suite.Counter)
@@ -871,7 +871,7 @@ def test_TelemetryTestSuite_calc_single_status_returns_tuple_of_value_from_call_
 
     mocker.patch(telemetry_test_suite.__name__ + '.Counter', return_value=fake_occurrences)
     mocker.patch.object(fake_occurrences, 'most_common', return_value=[[fake_max_occurrence]])
-    
+
     # Act
     result = cut.calc_single_status(arg_status_list, arg_mode)
 
@@ -887,7 +887,7 @@ def test_TelemetryTestSuite_calc_single_status_returns_tuple_of_value_from_call_
 
     num_fake_statuses = pytest.gen.randint(1, 10) # arbitrary, from 1 to 10 (0 not allowed, div by 0 error)
     fake_max_occurrence = MagicMock()
-    
+
     for i in range(num_fake_statuses):
         arg_status_list.append(MagicMock())
     fake_occurrences = telemetry_test_suite.Counter.__new__(telemetry_test_suite.Counter)
@@ -898,7 +898,7 @@ def test_TelemetryTestSuite_calc_single_status_returns_tuple_of_value_from_call_
 
     mocker.patch(telemetry_test_suite.__name__ + '.Counter', return_value=fake_occurrences)
     mocker.patch.object(fake_occurrences, 'most_common', return_value=[[fake_max_occurrence]])
-    
+
     # Act
     result = cut.calc_single_status(arg_status_list, arg_mode)
 
@@ -915,7 +915,7 @@ def test_TelemetryTestSuite_calc_single_status_returns_tuple_of_str_RED_and_1_pt
     num_fake_statuses = pytest.gen.randint(1, 10) # arbitrary, from 1 to 10 (0 not allowed, div by 0 error)
     num_red_statuses = pytest.gen.randint(1, num_fake_statuses) # arbitrary, from 1 to total statuses
     fake_max_occurrence = MagicMock()
-    
+
     for i in range(num_fake_statuses):
         arg_status_list.append(MagicMock())
 
@@ -927,7 +927,7 @@ def test_TelemetryTestSuite_calc_single_status_returns_tuple_of_str_RED_and_1_pt
 
     mocker.patch(telemetry_test_suite.__name__ + '.Counter', return_value=fake_occurrences)
     mocker.patch.object(fake_occurrences, 'most_common', return_value=[[fake_max_occurrence]])
-    
+
     # Act
     result = cut.calc_single_status(arg_status_list, arg_mode)
 
@@ -943,7 +943,7 @@ def test_TelemetryTestSuite_calc_single_status_default_given_mode_is_str_strict(
     num_fake_statuses = pytest.gen.randint(1, 10) # arbitrary, from 1 to 10 (0 not allowed, div by 0 error)
     num_red_statuses = pytest.gen.randint(1, num_fake_statuses) # arbitrary, from 1 to total statuses
     fake_max_occurrence = MagicMock()
-    
+
     for i in range(num_fake_statuses):
         arg_status_list.append(MagicMock())
 
@@ -955,7 +955,7 @@ def test_TelemetryTestSuite_calc_single_status_default_given_mode_is_str_strict(
 
     mocker.patch(telemetry_test_suite.__name__ + '.Counter', return_value=fake_occurrences)
     mocker.patch.object(fake_occurrences, 'most_common', return_value=[[fake_max_occurrence]])
-    
+
     # Act
     result = cut.calc_single_status(arg_status_list)
 
@@ -1005,7 +1005,7 @@ def test_TelemetryTestSuite_get_suite_status_returns_value_from_call_to_calc_sin
         fake_status = MagicMock()
 
         mocker.patch.object(fake_res, 'get_status', return_value=fake_status)
-        
+
         fake_latest_results.append(fake_res)
         fake_statuses.append(fake_status)
 
@@ -1113,7 +1113,7 @@ def test_TelemetryTestSuite_get_status_specific_mnemonics_returns_only_names_in_
         else:
             mocker.patch.object(fake_res, 'get_status', return_value=MagicMock())
         fake_latest_results[i] = fake_res
-            
+
     cut = TelemetryTestSuite.__new__(TelemetryTestSuite)
     cut.latest_results = fake_latest_results
 
@@ -1140,7 +1140,7 @@ def test_TelemetryTestSuite_get_status_specific_mnemonics_returns_all_names_in_l
         mocker.patch.object(fake_res, 'get_name', return_value=fake_name)
         fake_latest_results.append(fake_res)
         expected_names.append(fake_name)
-            
+
     cut = TelemetryTestSuite.__new__(TelemetryTestSuite)
     cut.latest_results = fake_latest_results
 

--- a/test/onair/src/systems/test_vehicle_rep.py
+++ b/test/onair/src/systems/test_vehicle_rep.py
@@ -9,7 +9,7 @@
 
 """ Test VehicleRepresentation Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.src.systems.vehicle_rep as vehicle_rep
 from onair.src.systems.vehicle_rep import VehicleRepresentation
@@ -32,7 +32,7 @@ def test_VehicleRepresentation__init__asserts_when_len_given_headers_is_not_eq_t
     # Act
     with pytest.raises(AssertionError) as e_info:
         cut.__init__(arg_headers, arg_tests)
-    
+
     # Assert
     assert vehicle_rep.len.call_count == 2
     call_list = set({})
@@ -54,7 +54,7 @@ def test_VehicleRepresentation__init__sets_status_to_Status_with_str_MISSION_and
     mocker.patch(vehicle_rep.__name__ + '.len', return_value=fake_len)
     mocker.patch(vehicle_rep.__name__ + '.Status', return_value=fake_status)
     mocker.patch(vehicle_rep.__name__ + '.TelemetryTestSuite', return_value=fake_test_suite)
-    
+
     # Act
     cut.__init__(arg_headers, arg_tests)
 
@@ -89,7 +89,7 @@ def test_VehicleRepresentation_update_calls_update_constructs_then_update_curr_d
     mock_manager.attach_mock(mocker.patch.object(cut.test_suite, 'execute_suite'), 'test_suite.execute_suite')
     mock_manager.attach_mock(mocker.patch.object(cut.test_suite, 'get_suite_status', return_value=fake_suite_status), 'test_suite.get_suite_status')
     mock_manager.attach_mock(mocker.patch.object(cut.status, 'set_status'), 'status.set_status')
-    
+
     # Act
     cut.update(arg_frame)
 
@@ -108,7 +108,7 @@ def test_VehicleRepresentation_update_constructs_does_nothing_when_knowledge_syn
     arg_frame = MagicMock()
 
     fake_constructs = []
-    
+
     cut = VehicleRepresentation.__new__(VehicleRepresentation)
     cut.knowledge_synthesis_constructs = fake_constructs
 
@@ -129,7 +129,7 @@ def test_VehicleRepresentation_update_constructs_calls_update_on_each_knowledge_
         fake_construct = MagicMock()
         fake_constructs.append(fake_construct)
         mocker.patch.object(fake_construct, 'update')
-    
+
     cut = VehicleRepresentation.__new__(VehicleRepresentation)
     cut.knowledge_synthesis_constructs = fake_constructs
 
@@ -316,7 +316,7 @@ def test_VehicleRepresentation_get_batch_status_reports_returngets_None():
 
     # Assert
     assert result == expected_result
-    
+
 # get_state_information tests
 def test_VehicleRepresentation_get_state_information_calls_render_reasoning_on_knowledge_synthesis_constructs(mocker):
     # Arrange
@@ -324,7 +324,7 @@ def test_VehicleRepresentation_get_state_information_calls_render_reasoning_on_k
     arg_headers = MagicMock()
     arg_tests = MagicMock()
     fake_render_reasoning_result = MagicMock()
-    
+
     fake_knowledge_synthesis_construct = MagicMock()
     fake_knowledge_synthesis_construct.component_name = 'foo'
 

--- a/test/onair/src/util/test_cleanup.py
+++ b/test/onair/src/util/test_cleanup.py
@@ -7,7 +7,7 @@
 # Licensed under the NASA Open Source Agreement version 1.3
 # See "NOSA GSC-19165-1 OnAIR.pdf"
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.src.util.cleanup as cleanup
 
@@ -21,7 +21,7 @@ def test_cleanup_setup_folders_creates_dir_when_given_results_path_does_not_exis
 
   # Act
   cleanup.setup_folders(arg_results_path)
-  
+
   # Assert
   assert cleanup.os.path.isdir.call_count == 1
   assert cleanup.os.mkdir.call_count == 1
@@ -36,7 +36,7 @@ def test_cleanup_setup_folders_does_not_create_dir_when_it_already_exists(mocker
 
   # Act
   cleanup.setup_folders(arg_results_path)
-  
+
   # Assert
   assert cleanup.os.path.isdir.call_count == 1
   assert cleanup.os.mkdir.call_count == 0

--- a/test/onair/src/util/test_data_conversion.py
+++ b/test/onair/src/util/test_data_conversion.py
@@ -9,12 +9,12 @@
 
 """ Test Data Conversion Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.src.util.data_conversion as data_conversion
 
 from numpy import ndarray
-    
+
 # status_to_oneHot tests
 def test_data_conversion_status_to_oneHot_returns_given_status_when_status_isinstance_of_np_ndarray(mocker):
     # Arrange

--- a/test/onair/src/util/test_file_io.py
+++ b/test/onair/src/util/test_file_io.py
@@ -8,7 +8,7 @@
 # See "NOSA GSC-19165-1 OnAIR.pdf"
 
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.src.util.file_io as file_io
 

--- a/test/onair/src/util/test_plugin_import.py
+++ b/test/onair/src/util/test_plugin_import.py
@@ -8,7 +8,7 @@
 # See "NOSA GSC-19165-1 OnAIR.pdf"
 
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.src.util.plugin_import as plugin_import
 
@@ -41,7 +41,7 @@ def test_plugin_import_returns_single_item_list_when_given_module_dict_contains_
     mocker.patch.dict(plugin_import.sys.modules)
     import_mock = mocker.patch('builtins.__import__', return_value=fake_plugin)
     mocker.patch.object(fake_plugin, 'Plugin', return_value=fake_Plugin_instance)
-    
+
     # Act
     result = plugin_import.import_plugins(arg_headers, arg_module_dict)
 

--- a/test/onair/src/util/test_print_io.py
+++ b/test/onair/src/util/test_print_io.py
@@ -8,7 +8,7 @@
 # See "NOSA GSC-19165-1 OnAIR.pdf"
 
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.src.util.print_io as print_io
 
@@ -21,7 +21,7 @@ def test_print_io_bcolors_OKBLUE_is_expected_value():
 
 def test_print_io_bcolors_OKGREEN_is_expected_value():
   assert print_io.bcolors.OKGREEN == '\033[92m'
-  
+
 def test_print_io_bcolors_WARNING_is_expected_value():
   assert print_io.bcolors.WARNING == '\033[93m'
 
@@ -33,7 +33,7 @@ def test_print_io_bcolors_ENDC_is_expected_value():
 
 def test_print_io_bcolors_BOLD_is_expected_value():
   assert print_io.bcolors.BOLD == '\033[1m'
-  
+
 def test_print_io_bcolors_UNDERLINE_is_expected_value():
   assert print_io.bcolors.UNDERLINE == '\033[4m'
 
@@ -47,7 +47,7 @@ def test_print_io_scolors_OKBLUE_is_set_to_bcolors_OKBLUE():
 
 def test_print_io_scolors_OKGREEN_is_set_to_bcolors_OKGREEN():
   assert print_io.scolors['OKGREEN'] == print_io.bcolors.OKGREEN
-  
+
 def test_print_io_scolors_WARNING_is_set_to_bcolors_WARNING():
   assert print_io.scolors['WARNING'] == print_io.bcolors.WARNING
 
@@ -59,7 +59,7 @@ def test_print_io_scolors_ENDC_is_set_to_bcolors_ENDC():
 
 def test_print_io_scolors_BOLD_is_set_to_bcolors_BOLD():
   assert print_io.scolors['BOLD'] == print_io.bcolors.BOLD
-  
+
 def test_print_io_scolors_UNDERLINE_is_set_to_bcolors_UNDERLINE():
   assert print_io.scolors['UNDERLINE'] == print_io.bcolors.UNDERLINE
 
@@ -111,7 +111,7 @@ def test_print_io_print_sim_step_inserts_given_step_num_into_text(mocker):
 
   # Act
   print_io.print_sim_step(arg_step_num)
-  
+
   # Assert
   assert print_io.print.call_args_list[0].args == (expected_print, )
 
@@ -129,7 +129,7 @@ def test_print_io_print_separator_uses_bcolors_HEADER_as_default_color_value(moc
 
   # Act
   print_io.print_separator()
-  
+
   # Assert
   assert print_io.print.call_args_list[0].args == (expected_print, )
 
@@ -146,7 +146,7 @@ def test_print_io_print_separator_prints_whatever_is_passed_in_as_color_at_start
 
   # Act
   print_io.print_separator(arg_color)
-  
+
   # Assert
   assert print_io.print.call_count == 1
   assert print_io.print.call_args_list[0].args == (expected_print, )
@@ -194,7 +194,7 @@ def test_print_io_update_header_prints_message_starting_with_whatever_is_given_a
 def test_print_io_print_msg_prints_message_starting_only_with_scolor_HEADER_when_no_clrs_arg_given(mocker):
     # Arrange
   arg_msg = MagicMock()
-  
+
   expected_scolor = print_io.scolors['HEADER']
   expected_print = []
   expected_print.append(expected_scolor)
@@ -261,7 +261,7 @@ def test_print_io_print_msg_prints_all_scolors_given_in_clrs(mocker):
 def test_print_io_print_mission_status_only_prints_agent_formatted_status_when_data_not_given(mocker):
   # Arrange
   arg_agent = MagicMock()
-  
+
   fake_mission_status = MagicMock()
   fake_status = MagicMock()
 
@@ -273,7 +273,7 @@ def test_print_io_print_mission_status_only_prints_agent_formatted_status_when_d
 
   # Act
   print_io.print_system_status(arg_agent)
-  
+
   # Assert
   assert print_io.format_status.call_count == 1
   assert print_io.format_status.call_args_list[0].args == (fake_mission_status,)
@@ -284,7 +284,7 @@ def test_print_io_print_mission_status_only_prints_agent_formatted_status_when_d
   # Arrange
   arg_agent = MagicMock()
   arg_data = None
-  
+
   fake_mission_status = MagicMock()
   fake_status = MagicMock()
 
@@ -296,7 +296,7 @@ def test_print_io_print_mission_status_only_prints_agent_formatted_status_when_d
 
   # Act
   print_io.print_system_status(arg_agent, arg_data)
-  
+
   # Assert
   assert print_io.format_status.call_count == 1
   assert print_io.format_status.call_args_list[0].args == (fake_mission_status,)
@@ -307,7 +307,7 @@ def test_print_io_print_mission_status_only_prints_agent_formatted_status_when_d
   # Arrange
   arg_agent = MagicMock()
   arg_data = MagicMock()
-  
+
   fake_mission_status = MagicMock()
   fake_status = MagicMock()
 
@@ -321,7 +321,7 @@ def test_print_io_print_mission_status_only_prints_agent_formatted_status_when_d
 
   # Act
   print_io.print_system_status(arg_agent, arg_data)
-  
+
   # Assert
   assert print_io.format_status.call_count == 1
   assert print_io.format_status.call_args_list[0].args == (fake_mission_status,)
@@ -420,7 +420,7 @@ def test_print_io_subsystem_status_str_returns_expected_string_when_stat_exists_
   assert print_io.str.call_args_list[1].args == (fake_stat, )
   assert print_io.str.call_args_list[2].args == (fake_uncertainty, )
   assert result == expected_s
-  
+
 
 # subsystem_str tests
 def test_print_io_subsystem_str_returns_string_without_any_data_when_headers_tests_and_test_data_empty(mocker):
@@ -489,13 +489,13 @@ def test_print_io_format_status_returns_all_headers_in_formatted_string_when_occ
   # Arrange
   num_headers = pytest.gen.randint(1, 10) # arbitrary from 1 to 10
   arg_headers = []
-  
+
   expected_result = ''
 
   for i in range(num_headers):
     arg_headers.append(str(MagicMock()))
     expected_result = expected_result + '\n  -- ' + arg_headers[i]
-  
+
   # Act
   result = print_io.headers_string(arg_headers)
 

--- a/test/onair/src/util/test_sim_io.py
+++ b/test/onair/src/util/test_sim_io.py
@@ -7,7 +7,7 @@
 # Licensed under the NASA Open Source Agreement version 1.3
 # See "NOSA GSC-19165-1 OnAIR.pdf"
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import onair.src.util.sim_io as sim_io
 
@@ -44,7 +44,7 @@ def test_sim_io_render_reasoning_writes_txt_and_csv_files_even_when_list_is_empt
   assert open.call_args_list[1].args == (fake_full_path,)
   assert open.call_args_list[1].kwargs == {'mode':'a'}
   assert fake_file_iterator.write.call_args_list[3].args == ('time_step, cohens_kappa, faults, subgraph\n',)
-  
+
 def test_sim_io_render_reasoning_writes_txt_and_csv_files_with_entry_for_each_given_diagnosis_in_list(mocker):
   # Arrange
   SAVE_PATH = 'ONAIR_DIAGNOSIS_SAVE_PATH'
@@ -83,13 +83,13 @@ def test_sim_io_render_reasoning_writes_txt_and_csv_files_with_entry_for_each_gi
   assert fake_file_iterator.write.call_args_list[0].args == ('==========================================================\n',)
   assert fake_file_iterator.write.call_args_list[1].args == ('                        DIAGNOSIS                         \n',)
   assert fake_file_iterator.write.call_args_list[2].args == ('==========================================================\n',)
-  
+
   for i in range(5):
     assert fake_file_iterator.write.call_args_list[i*4 + 3].args == ('\n----------------------------------------------------------\n',)
     assert fake_file_iterator.write.call_args_list[i*4 + 4].args == ('***                DIAGNOSIS AT FRAME ' + fake_timestep + '               ***\n',)
     assert fake_file_iterator.write.call_args_list[i*4 + 5].args == (fake_str,)
     assert fake_file_iterator.write.call_args_list[i*4 + 6].args == ('----------------------------------------------------------\n',)
-  
+
   assert sim_io.os.environ.get.call_args_list[1].args == (SAVE_PATH,)
   assert sim_io.os.path.join.call_args_list[1].args == (fake_system_filename, 'diagnosis.csv')
   assert open.call_args_list[1].args == (fake_full_path,)
@@ -98,7 +98,7 @@ def test_sim_io_render_reasoning_writes_txt_and_csv_files_with_entry_for_each_gi
 
   for j in range(5):
     assert fake_file_iterator.write.call_args_list[j + i*4 + 8].args == (fake_results_csv,)
-    
+
 def test_sim_io_render_viz_does_only_stattest_render_viz_does_status_sensor_and_diagnosis_reports_when_diagnosis_is_givenus_and_sensor_reports_when_diagnosis_is_not_given(mocker):
   # Arrange
   SAVE_PATH = 'ONAIR_VIZ_SAVE_PATH'
@@ -137,7 +137,7 @@ def test_sim_io_render_viz_does_only_stattest_render_viz_does_status_sensor_and_
   assert sim_io.os.path.join.call_args_list[1].args == (fake_system_filename, 'faults.json')
   assert open.call_args_list[1].args == (fake_full_path, 'w')
   assert sim_io.json.dump.call_args_list[1].args == (expected_sensor_status_report, fake_iterator)
-  
+
 def test_sim_io_render_viz_does_only_status_and_sensor_reports_when_diagnosis_is_given_as_None(mocker):
   # Arrange
   SAVE_PATH = 'ONAIR_VIZ_SAVE_PATH'
@@ -177,7 +177,7 @@ def test_sim_io_render_viz_does_only_status_and_sensor_reports_when_diagnosis_is
   assert sim_io.os.path.join.call_args_list[1].args == (fake_system_filename, 'faults.json')
   assert open.call_args_list[1].args == (fake_full_path, 'w')
   assert sim_io.json.dump.call_args_list[1].args == (expected_sensor_status_report, fake_iterator)
-  
+
 def test_sim_io_render_viz_does_status_sensor_and_diagnosis_reports_when_diagnosis_is_given(mocker):
   # Arrange
   SAVE_PATH = 'ONAIR_VIZ_SAVE_PATH'

--- a/test/plugins/generic/test_generic_plugin.py
+++ b/test/plugins/generic/test_generic_plugin.py
@@ -9,7 +9,7 @@
 
 """ Test Generic Plugin Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from plugins.generic.generic_plugin import Plugin
 

--- a/test/plugins/kalman/test_kalman_plugin.py
+++ b/test/plugins/kalman/test_kalman_plugin.py
@@ -9,7 +9,7 @@
 
 """ Test Kalman Plugin Functionality """
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 import onair
 
 from plugins.kalman import kalman_plugin


### PR DESCRIPTION
Now using unittest.mock as it is included with python distrobution
  - since Python 3.3  
  
Also cleaned up trailing whitespace when files saved (automated)