### PR TITLE
Add Python data types to the data_handling module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 __pycache__/
 .coverage
+.vscode

--- a/onair/data_handling/csv_parser.py
+++ b/onair/data_handling/csv_parser.py
@@ -20,12 +20,12 @@ from onair.data_handling.parser_util import *
 
 class DataSource(OnAirDataSource):
 
-    def process_data_file(self, data_file):
+    def process_data_file(self, data_file: str) -> None:
         self.sim_data = self.parse_csv_data(data_file)
         self.frame_index = 0
 
 ##### INITIAL PROCESSING ####
-    def parse_csv_data(self, data_file):
+    def parse_csv_data(self, data_file: str) -> list:
         #Read in the data set
 
         all_data = []
@@ -46,19 +46,19 @@ class DataSource(OnAirDataSource):
 
         return all_data
 
-    def parse_meta_data_file(self, meta_data_file, ss_breakdown):
+    def parse_meta_data_file(self, meta_data_file: str, ss_breakdown: bool) -> dict:
         return extract_meta_data_handle_ss_breakdown(meta_data_file, ss_breakdown)
 
 ##### GETTERS ##################################
 
-    def get_vehicle_metadata(self):
+    def get_vehicle_metadata(self) -> tuple:
         return self.all_headers, self.binning_configs['test_assignments']
 
     # Get the data at self.index and increment the index
-    def get_next(self):
+    def get_next(self) -> list:
         self.frame_index = self.frame_index + 1
         return self.sim_data[self.frame_index - 1]
 
     # Return whether or not the index has finished traveling through the data
-    def has_more(self):
+    def has_more(self) -> bool:
         return self.frame_index < len(self.sim_data)

--- a/onair/data_handling/on_air_data_source.py
+++ b/onair/data_handling/on_air_data_source.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod
 from .parser_util import * 
 
 class OnAirDataSource(ABC):
-    def __init__(self, data_file, meta_file, ss_breakdown = False):
+    def __init__(self, data_file: str, meta_file: str, ss_breakdown: bool = False) -> None:
         """An initial parsing needs to happen in order to use the parser classes
             This means that, if you want to use this class to parse in real time,
             it needs to at least have seen one sample of the anticipated format """
@@ -32,28 +32,28 @@ class OnAirDataSource(ABC):
         self.process_data_file(self.raw_data_file)
 
     @abstractmethod
-    def parse_meta_data_file(self, meta_data_file, ss_breakdown):
+    def parse_meta_data_file(self, meta_data_file: str, ss_breakdown: bool) -> dict:
         """
         Create the configs that will be used to populate the binning_configs for the data files
         """
         raise NotImplementedError
 
     @abstractmethod
-    def process_data_file(self, data_file):
+    def process_data_file(self, data_file: str) -> None:
         """
         Read data frames from the specified file.
         """
         raise NotImplementedError
 
     @abstractmethod
-    def get_next(self):
+    def get_next(self) -> list:
         """
         Return a frame of data
         """
         raise NotImplementedError
 
     @abstractmethod
-    def has_more(self):
+    def has_more(self) -> bool:
         """
         Used by file-based data to indicate if there are more frames (True) or if the end of the file has been reached (False)
         """

--- a/onair/data_handling/parser_util.py
+++ b/onair/data_handling/parser_util.py
@@ -11,7 +11,7 @@ import os
 from .tlm_json_parser import parseTlmConfJson, str2lst
 import datetime
 
-def extract_meta_data_handle_ss_breakdown(meta_data_file, ss_breakdown):
+def extract_meta_data_handle_ss_breakdown(meta_data_file: str, ss_breakdown: bool) -> dict:
     parsed_meta_data = extract_meta_data(meta_data_file)
     if ss_breakdown == False:
         num_elements = len(parsed_meta_data['subsystem_assignments'])
@@ -19,7 +19,7 @@ def extract_meta_data_handle_ss_breakdown(meta_data_file, ss_breakdown):
     return parsed_meta_data
 
 ## Method to extract configuration data and return 3 dictionaries
-def extract_meta_data(meta_data_file):
+def extract_meta_data(meta_data_file: str) -> dict:
     assert meta_data_file != ''
 
     configs = parseTlmConfJson(meta_data_file)
@@ -42,7 +42,7 @@ def extract_meta_data(meta_data_file):
 
     return configs
 
-def floatify_input(_input, remove_str=False):
+def floatify_input(_input: list, remove_str: bool = False) -> list:
     floatified = []
     for i in _input:
         try:
@@ -60,7 +60,7 @@ def floatify_input(_input, remove_str=False):
                 continue
     return floatified
 
-def convert_str_to_timestamp(time_str):
+def convert_str_to_timestamp(time_str: str) -> float:
     try:
         t = datetime.datetime.strptime(time_str, '%Y-%j-%H:%M:%S.%f')
         return t.timestamp()

--- a/onair/data_handling/redis_adapter.py
+++ b/onair/data_handling/redis_adapter.py
@@ -25,7 +25,7 @@ from onair.data_handling.parser_util import *
 
 class DataSource(OnAirDataSource):
 
-    def __init__(self, data_file, meta_file, ss_breakdown = False):
+    def __init__(self, data_file: str, meta_file: str, ss_breakdown: bool = False) -> None:
         super().__init__(data_file, meta_file, ss_breakdown)
         self.address = 'localhost'
         self.port = 6379
@@ -40,7 +40,7 @@ class DataSource(OnAirDataSource):
         self.connect()
         self.subscribe(self.subscriptions)
 
-    def connect(self):
+    def connect(self) -> None:
         """Establish connection to REDIS server."""
         print_msg('Redis adapter connecting to server...')
         self.server = redis.Redis(self.address, self.port, self.db)
@@ -48,7 +48,7 @@ class DataSource(OnAirDataSource):
         if self.server.ping():
             print_msg('... connected!')
 
-    def subscribe(self, subscriptions):
+    def subscribe(self, subscriptions: list) -> None:
         """Subscribe to REDIS message channel(s) and launch listener thread."""
         if len(subscriptions) != 0 and self.server.ping():
             self.pubsub = self.server.pubsub()
@@ -62,7 +62,7 @@ class DataSource(OnAirDataSource):
         else:
             print_msg(f"No subscriptions given!")
 
-    def parse_meta_data_file(self, meta_data_file, ss_breakdown):
+    def parse_meta_data_file(self, meta_data_file: str, ss_breakdown: bool) -> dict:
         configs = extract_meta_data_handle_ss_breakdown(meta_data_file, ss_breakdown)
         meta = parseJson(meta_data_file)
         if 'redis_subscriptions' in meta.keys():
@@ -72,13 +72,13 @@ class DataSource(OnAirDataSource):
 
         return configs
 
-    def process_data_file(self, data_file):
+    def process_data_file(self, data_file: str) -> None:
         print("Redis Adapter ignoring file")
 
-    def get_vehicle_metadata(self):
+    def get_vehicle_metadata(self) -> tuple:
         return self.all_headers, self.binning_configs['test_assignments']
 
-    def get_next(self):
+    def get_next(self) -> list:
         """Provides the latest data from REDIS channel"""
         data_available = False
 
@@ -97,11 +97,11 @@ class DataSource(OnAirDataSource):
 
         return self.currentData[read_index]['data']
 
-    def has_more(self):
+    def has_more(self) -> bool:
         """Live connection should always return True"""
         return True
 
-    def message_listener(self):
+    def message_listener(self) -> None:
         """Loop for listening for messages on channel"""
         for message in self.pubsub.listen():
             if message['type'] == 'message':
@@ -114,6 +114,6 @@ class DataSource(OnAirDataSource):
                 with self.new_data_lock:
                     self.new_data = True
 
-    def has_data(self):
+    def has_data(self) -> bool:
         return self.new_data
     

--- a/onair/data_handling/tlm_json_parser.py
+++ b/onair/data_handling/tlm_json_parser.py
@@ -11,7 +11,7 @@ import ast
 import json
 
 # parse tlm config json file
-def parseTlmConfJson(file_path):
+def parseTlmConfJson(file_path: str) -> dict:
     data = parseJson(file_path)
     reorg_data = reorganizeTlmDict(data)
 
@@ -62,7 +62,7 @@ def parseTlmConfJson(file_path):
     return configs
 
 # process tlm dict into dict of labels and their attributes
-def reorganizeTlmDict(data):
+def reorganizeTlmDict(data: dict) -> dict:
     processed_data = {}
     
     for s in data['subsystems']:
@@ -72,14 +72,14 @@ def reorganizeTlmDict(data):
     
     return processed_data
 
-def str2lst(string):
+def str2lst(string: str) -> list | None:
     try:
         return ast.literal_eval(string)
     except:
         print("Unable to process string representation of list")
         # return string
 
-def parseJson(path):
+def parseJson(path: str) -> dict:
     file = open(path, 'rb')
     file_str = file.read()
 


### PR DESCRIPTION
# Changes
* Add Python data types to each function definition in the `data_handling` module
* Working towards #109 
* Used [Instagram/MonkeyType](https://github.com/Instagram/MonkeyType) to run `driver.py` and get some working function definitions with types, and tried to fill in the rest based off of what was returned by those functions. Please make sure that the function parameter and return types are actually correct
* Decided to stick with first-level types e.g. `list` instead of `list[float]` as some types are deeply nested, complicated multilevel types
* Added `.vscode/` (VSCode configurations folder) to `.gitignore`

# Testing
* `python driver.py -t` succeeded
* `python driver.py` did not return any errors