### PR TITLE
Updates to allow more robust naming and usage of plugins

### DIFF
--- a/onair/src/util/plugin_import.py
+++ b/onair/src/util/plugin_import.py
@@ -14,14 +14,34 @@ Function to import user-specified plugins (from config files) into interfaces
 
 import importlib.util
 import sys
+import os
 
 def import_plugins(headers, module_dict):
     plugin_list = []
-    for module_name in list(module_dict.keys()):
-                spec = importlib.util.spec_from_file_location(module_name, module_dict[module_name])
-                module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(module)
-                sys.modules[module_name] = module         
-                plugin = __import__(f'{module_name}.{module_name}_plugin', fromlist=[f'{module_name}_plugin'])            
-                plugin_list.append(plugin.Plugin(module_name,headers))
+    init_filename = "__init__.py"
+    for construct_name, module_path in module_dict.items():
+        true_path = module_path
+        # Compatibility for plugin paths that already include __init__.py
+        if module_path.endswith(init_filename):
+            true_path = module_path[:-len(init_filename) - 1]
+        # Last directory name is the module name
+        mod_name = os.path.basename(true_path)
+        # import module if not already available
+        if mod_name not in sys.modules:
+            # add init file to get proper path for spec
+            full_path = os.path.join(true_path, init_filename)
+            # define spec for module loading
+            spec = importlib.util.spec_from_file_location(mod_name, full_path)
+            # create uninitialize module from spec
+            module = importlib.util.module_from_spec(spec)
+            # initialize the created module
+            spec.loader.exec_module(module)
+            # add plugin module to system for importation
+            sys.modules[mod_name] = module
+        # import the created module's plugin file for use
+        plugin_name = f'{mod_name}_plugin'
+        plugin = __import__(f'{mod_name}.{plugin_name}',
+                            fromlist=[plugin_name])
+        # add an instance of the module's was an OnAIR plugin
+        plugin_list.append(plugin.Plugin(construct_name, headers))
     return(plugin_list)

--- a/test/onair/src/util/test_plugin_import.py
+++ b/test/onair/src/util/test_plugin_import.py
@@ -8,6 +8,7 @@
 # See "NOSA GSC-19165-1 OnAIR.pdf"
 
 import pytest
+import os
 from unittest.mock import MagicMock
 
 import onair.src.util.plugin_import as plugin_import
@@ -23,18 +24,26 @@ def test_plugin_import_returns_empty_list_when_given_module_dict_is_empty():
     # Assert
     assert result == []
 
-def test_plugin_import_returns_single_item_list_when_given_module_dict_contains_one_key_value_pair(mocker):
+def test_plugin_import_returns_single_item_list_when_given_module_dict_contains_one_key_value_pair_no_init_and_not_already_in_sys(mocker):
     # Arrange
     arg_headers = MagicMock()
-    fake_module_name = MagicMock()
+    fake_construct_name = MagicMock()
+    fake_mod_name = MagicMock()
     fake_module_path = MagicMock()
-    arg_module_dict = {fake_module_name:fake_module_path}
+    fake_full_path = MagicMock()
+    arg_module_dict = {fake_construct_name:fake_module_path}
 
     fake_spec = MagicMock()
     fake_module = MagicMock()
     fake_plugin = MagicMock()
     fake_Plugin_instance = MagicMock()
 
+    mocker.patch.object(fake_module_path, 'endswith',
+                        return_value=False)
+    mocker.patch(plugin_import.__name__ + '.os.path.basename',
+                 return_value=fake_mod_name)
+    mocker.patch(plugin_import.__name__ + '.os.path.join',
+                 return_value=fake_full_path)
     mocker.patch(plugin_import.__name__ + '.importlib.util.spec_from_file_location', return_value=fake_spec)
     mocker.patch(plugin_import.__name__ + '.importlib.util.module_from_spec', return_value=fake_module)
     mocker.patch.object(fake_spec, 'loader.exec_module')
@@ -50,17 +59,223 @@ def test_plugin_import_returns_single_item_list_when_given_module_dict_contains_
     # Therefore import_mock is checked first then stopped, so other items failures output correctly
     # When this test fails because of INTERNALERROR the problem is with import_mock
     assert import_mock.call_count == 1
-    assert import_mock.call_args_list[0].args == (f'{fake_module_name}.{fake_module_name}_plugin', )
-    assert import_mock.call_args_list[0].kwargs == ({'fromlist': [f"{fake_module_name}_plugin"]})
-    # Without the stop of import_mock any other fails will also cause INTERNALERROR
+    assert import_mock.call_args_list[0].args == (f'{fake_mod_name}.{fake_mod_name}_plugin', )
+    assert import_mock.call_args_list[0].kwargs == ({'fromlist': [f"{fake_mod_name}_plugin"]})
+    # # Without the stop of import_mock any other fails will also cause INTERNALERROR
     mocker.stop(import_mock)
 
+    assert plugin_import.os.path.basename.call_count == 1
+    assert plugin_import.os.path.basename.call_args_list[0].args == (fake_module_path, )
     assert plugin_import.importlib.util.spec_from_file_location.call_count == 1
-    assert plugin_import.importlib.util.spec_from_file_location.call_args_list[0].args == (fake_module_name, fake_module_path)
+    assert plugin_import.importlib.util.spec_from_file_location.call_args_list[0].args == (fake_mod_name, fake_full_path)
     assert plugin_import.importlib.util.module_from_spec.call_count == 1
     assert plugin_import.importlib.util.module_from_spec.call_args_list[0].args == (fake_spec,)
     assert fake_spec.loader.exec_module.call_count == 1
     assert fake_spec.loader.exec_module.call_args_list[0].args == (fake_module, )
-    assert fake_module_name in plugin_import.sys.modules
-    assert plugin_import.sys.modules[fake_module_name] == fake_module
+    assert fake_mod_name in plugin_import.sys.modules
+    assert plugin_import.sys.modules[fake_mod_name] == fake_module
     assert result == [fake_Plugin_instance]
+
+def test_plugin_import_returns_single_item_list_when_given_module_dict_contains_one_key_value_pair_has_init_and_not_already_in_sys(mocker):
+    # Arrange
+    arg_headers = MagicMock()
+    fake_construct_name = MagicMock()
+    fake_mod_name = MagicMock()
+    fake_pathing = []
+    for _ in range(pytest.gen.randint(1, 5)): # 1-5 arbitrary length
+        fake_pathing.append(str(MagicMock()))
+    expected_true_path = os.path.join(*fake_pathing)
+    fake_pathing.append("__init__.py")
+    fake_module_path = os.path.join(*fake_pathing)
+    fake_full_path = MagicMock()
+    arg_module_dict = {fake_construct_name:fake_module_path}
+
+    fake_spec = MagicMock()
+    fake_module = MagicMock()
+    fake_plugin = MagicMock()
+    fake_Plugin_instance = MagicMock()
+
+    mocker.patch(plugin_import.__name__ + '.os.path.basename',
+                 return_value=fake_mod_name)
+    mocker.patch(plugin_import.__name__ + '.os.path.join',
+                 return_value=fake_full_path)
+    mocker.patch(plugin_import.__name__ + '.importlib.util.spec_from_file_location', return_value=fake_spec)
+    mocker.patch(plugin_import.__name__ + '.importlib.util.module_from_spec', return_value=fake_module)
+    mocker.patch.object(fake_spec, 'loader.exec_module')
+    mocker.patch.dict(plugin_import.sys.modules)
+    import_mock = mocker.patch('builtins.__import__', return_value=fake_plugin)
+    mocker.patch.object(fake_plugin, 'Plugin', return_value=fake_Plugin_instance)
+
+    # Act
+    result = plugin_import.import_plugins(arg_headers, arg_module_dict)
+
+    # Assert
+    # If import checks fail, test fails with INTERNALERROR due to test output using patched code
+    # Therefore import_mock is checked first then stopped, so other items failures output correctly
+    # When this test fails because of INTERNALERROR the problem is with import_mock
+    assert import_mock.call_count == 1
+    assert import_mock.call_args_list[0].args == (f'{fake_mod_name}.{fake_mod_name}_plugin', )
+    assert import_mock.call_args_list[0].kwargs == ({'fromlist': [f"{fake_mod_name}_plugin"]})
+    # # Without the stop of import_mock any other fails will also cause INTERNALERROR
+    mocker.stop(import_mock)
+
+    assert plugin_import.os.path.basename.call_count == 1
+    assert plugin_import.os.path.basename.call_args_list[0].args == (expected_true_path, )
+    assert plugin_import.importlib.util.spec_from_file_location.call_count == 1
+    assert plugin_import.importlib.util.spec_from_file_location.call_args_list[0].args == (fake_mod_name, fake_full_path)
+    assert plugin_import.importlib.util.module_from_spec.call_count == 1
+    assert plugin_import.importlib.util.module_from_spec.call_args_list[0].args == (fake_spec,)
+    assert fake_spec.loader.exec_module.call_count == 1
+    assert fake_spec.loader.exec_module.call_args_list[0].args == (fake_module, )
+    assert fake_mod_name in plugin_import.sys.modules
+    assert plugin_import.sys.modules[fake_mod_name] == fake_module
+    assert result == [fake_Plugin_instance]
+
+def test_plugin_import_returns_single_item_list_when_given_module_dict_contains_one_key_value_pair_no_init_and_exists_in_sys(mocker):
+    # Arrange
+    arg_headers = MagicMock()
+    fake_construct_name = MagicMock()
+    fake_mod_name = MagicMock()
+    fake_module_path = MagicMock()
+    fake_full_path = MagicMock()
+    arg_module_dict = {fake_construct_name:fake_module_path}
+
+    fake_plugin = MagicMock()
+    fake_Plugin_instance = MagicMock()
+
+    mocker.patch.object(fake_module_path, 'endswith',
+                        return_value=False)
+    mocker.patch(plugin_import.__name__ + '.os.path.basename',
+                 return_value=fake_mod_name)
+    mocker.patch(plugin_import.__name__ + '.os.path.join',
+                 return_value=fake_full_path)
+    mocker.patch(plugin_import.__name__ + '.importlib.util.spec_from_file_location')
+    mocker.patch.dict(plugin_import.sys.modules, {fake_mod_name:None})
+    import_mock = mocker.patch('builtins.__import__', return_value=fake_plugin)
+    mocker.patch.object(fake_plugin, 'Plugin', return_value=fake_Plugin_instance)
+
+    # Act
+    result = plugin_import.import_plugins(arg_headers, arg_module_dict)
+
+    # Assert
+    # If import checks fail, test fails with INTERNALERROR due to test output using patched code
+    # Therefore import_mock is checked first then stopped, so other items failures output correctly
+    # When this test fails because of INTERNALERROR the problem is with import_mock
+    assert import_mock.call_count == 1
+    assert import_mock.call_args_list[0].args == (f'{fake_mod_name}.{fake_mod_name}_plugin', )
+    assert import_mock.call_args_list[0].kwargs == ({'fromlist': [f"{fake_mod_name}_plugin"]})
+    # # Without the stop of import_mock any other fails will also cause INTERNALERROR
+    mocker.stop(import_mock)
+
+    assert plugin_import.os.path.basename.call_count == 1
+    assert plugin_import.os.path.basename.call_args_list[0].args == (fake_module_path, )
+    assert plugin_import.importlib.util.spec_from_file_location.call_count == 0
+    assert fake_mod_name in plugin_import.sys.modules
+    assert plugin_import.sys.modules[fake_mod_name] == None
+    assert result == [fake_Plugin_instance]
+
+def test_plugin_import_returns_single_item_list_when_given_module_dict_contains_one_key_value_pair_has_init_and_exists_in_sys(mocker):
+    # Arrange
+    arg_headers = MagicMock()
+    fake_construct_name = MagicMock()
+    fake_mod_name = MagicMock()
+    fake_pathing = []
+    for _ in range(pytest.gen.randint(1, 5)): # 1-5 arbitrary length
+        fake_pathing.append(str(MagicMock()))
+    expected_true_path = os.path.join(*fake_pathing)
+    fake_pathing.append("__init__.py")
+    fake_module_path = os.path.join(*fake_pathing)
+    fake_full_path = MagicMock()
+    arg_module_dict = {fake_construct_name:fake_module_path}
+
+    fake_plugin = MagicMock()
+    fake_Plugin_instance = MagicMock()
+
+    mocker.patch(plugin_import.__name__ + '.os.path.basename',
+                 return_value=fake_mod_name)
+    mocker.patch(plugin_import.__name__ + '.os.path.join',
+                 return_value=fake_full_path)
+    mocker.patch(plugin_import.__name__ + '.importlib.util.spec_from_file_location')
+    mocker.patch.dict(plugin_import.sys.modules, {fake_mod_name:None})
+    import_mock = mocker.patch('builtins.__import__', return_value=fake_plugin)
+    mocker.patch.object(fake_plugin, 'Plugin', return_value=fake_Plugin_instance)
+
+    # Act
+    result = plugin_import.import_plugins(arg_headers, arg_module_dict)
+
+    # Assert
+    # If import checks fail, test fails with INTERNALERROR due to test output using patched code
+    # Therefore import_mock is checked first then stopped, so other items failures output correctly
+    # When this test fails because of INTERNALERROR the problem is with import_mock
+    assert import_mock.call_count == 1
+    assert import_mock.call_args_list[0].args == (f'{fake_mod_name}.{fake_mod_name}_plugin', )
+    assert import_mock.call_args_list[0].kwargs == ({'fromlist': [f"{fake_mod_name}_plugin"]})
+    # # Without the stop of import_mock any other fails will also cause INTERNALERROR
+    mocker.stop(import_mock)
+
+    assert plugin_import.os.path.basename.call_count == 1
+    assert plugin_import.os.path.basename.call_args_list[0].args == (expected_true_path, )
+    assert plugin_import.importlib.util.spec_from_file_location.call_count == 0
+    assert fake_mod_name in plugin_import.sys.modules
+    assert plugin_import.sys.modules[fake_mod_name] == None
+    assert result == [fake_Plugin_instance]
+
+def test_plugin_import_returns_two_item_list_when_given_module_dict_contains_two_key_value_pairs_that_use_same_module(mocker):
+    # Arrange
+    arg_headers = MagicMock()
+    fake_construct_name_1 = MagicMock()
+    fake_construct_name_2 = MagicMock()
+    fake_mod_name = MagicMock()
+    fake_module_path = MagicMock()
+    fake_full_path = MagicMock()
+    arg_module_dict = {fake_construct_name_1:fake_module_path,
+                       fake_construct_name_2:fake_module_path}
+
+    fake_spec = MagicMock()
+    fake_module = MagicMock()
+    fake_plugin = MagicMock()
+    fake_Plugin_instance_1 = MagicMock()
+    fake_Plugin_instance_2 = MagicMock()
+
+    mocker.patch.object(fake_module_path, 'endswith',
+                        return_value=False)
+    mocker.patch(plugin_import.__name__ + '.os.path.basename',
+                 return_value=fake_mod_name)
+    mocker.patch(plugin_import.__name__ + '.os.path.join',
+                 return_value=fake_full_path)
+    mocker.patch(plugin_import.__name__ + '.importlib.util.spec_from_file_location', return_value=fake_spec)
+    mocker.patch(plugin_import.__name__ + '.importlib.util.module_from_spec', return_value=fake_module)
+    mocker.patch.object(fake_spec, 'loader.exec_module')
+    mocker.patch.dict(plugin_import.sys.modules)
+    import_mock = mocker.patch('builtins.__import__', return_value=fake_plugin)
+    mocker.patch.object(fake_plugin,
+                        'Plugin',
+                        side_effect=[fake_Plugin_instance_1,
+                                     fake_Plugin_instance_2])
+
+    # Act
+    result = plugin_import.import_plugins(arg_headers, arg_module_dict)
+
+    # Assert
+    # If import checks fail, test fails with INTERNALERROR due to test output using patched code
+    # Therefore import_mock is checked first then stopped, so other items failures output correctly
+    # When this test fails because of INTERNALERROR the problem is with import_mock
+    assert import_mock.call_count == 2
+    assert import_mock.call_args_list[0].args == (f'{fake_mod_name}.{fake_mod_name}_plugin', )
+    assert import_mock.call_args_list[0].kwargs == ({'fromlist': [f"{fake_mod_name}_plugin"]})
+    assert import_mock.call_args_list[1].args == (f'{fake_mod_name}.{fake_mod_name}_plugin', )
+    assert import_mock.call_args_list[1].kwargs == ({'fromlist': [f"{fake_mod_name}_plugin"]})
+    # # Without the stop of import_mock any other fails will also cause INTERNALERROR
+    mocker.stop(import_mock)
+
+    assert plugin_import.os.path.basename.call_count == 2
+    assert plugin_import.os.path.basename.call_args_list[0].args == (fake_module_path, )
+    assert plugin_import.importlib.util.spec_from_file_location.call_count == 1
+    assert plugin_import.importlib.util.spec_from_file_location.call_args_list[0].args == (fake_mod_name, fake_full_path)
+    assert plugin_import.importlib.util.module_from_spec.call_count == 1
+    assert plugin_import.importlib.util.module_from_spec.call_args_list[0].args == (fake_spec,)
+    assert fake_spec.loader.exec_module.call_count == 1
+    assert fake_spec.loader.exec_module.call_args_list[0].args == (fake_module, )
+    assert fake_mod_name in plugin_import.sys.modules
+    assert plugin_import.sys.modules[fake_mod_name] == fake_module
+    assert result == [fake_Plugin_instance_1, fake_Plugin_instance_2]


### PR DESCRIPTION
Plugins can now be named something other than the module name  
This also allows re-use of the same plugin module in a single config file  
 - each plugin will be a different instance
 
The `__init__.py` file is required to exist in the directory for the plugin module  
Backward compatibility with including `__init__.py` at end of module path is included  
  - config path must at least point to directory of module that will be used 
  - having the `__init__.py` in the plugin path is now optional   

Module is now dynamically known by last dir in path (minus init file if included)  
Unit tests updated to reflect changes