### PR TITLE
126 provide some backwards compatibility with previous python versions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v3
@@ -15,7 +18,7 @@ jobs:
       with:
         activate-environment: onair
         environment-file: environment.yml
-        python-version: 3.11.2
+        python-version: ${{ matrix.python-version }}
         auto-activate-base: false
     - name: Install dependencies
       shell: bash -l {0}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -12,7 +12,7 @@ jobs:
         python-version: ['3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up OnAIR test environment
       uses: conda-incubator/setup-miniconda@v3
       with:
@@ -32,4 +32,4 @@ jobs:
       shell: bash -l {0}
       run: coverage report --skip-empty
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11]
+        python-version: [3.11]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v4
@@ -32,4 +32,4 @@ jobs:
       shell: bash -l {0}
       run: coverage report --skip-empty
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -32,4 +32,4 @@ jobs:
       shell: bash -l {0}
       run: coverage report --skip-empty
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.9, 3.11]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.11]
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/environment.yml
+++ b/environment.yml
@@ -3,12 +3,12 @@ channels:
   - default
   - conda-forge
 dependencies:
-  - python==3.11.2
-  - numpy==1.23.4
-  - coverage==6.5.0
-  - pytest==7.2.0
-  - pytest-mock==3.10.0
-  - pytest-randomly==3.12.0
+  - python>=3.9,<3.12
+  - numpy
+  - coverage
+  - pytest
+  - pytest-mock
+  - pytest-randomly
   - pip
   - pip:
-    - redis==4.6.0
+    - redis

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - default
   - conda-forge
 dependencies:
-  - python>=3.9,<3.12
+  - python>=3.8,<3.12
   - numpy
   - coverage
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - default
   - conda-forge
 dependencies:
-  - python>=3.8,<3.12
+  - python>=3.8,<3.13
   - numpy
   - coverage
   - pytest


### PR DESCRIPTION
CI runs show unit test compatibility with Python versions 3.8 thru 3.12.
While this does not ensure "production" usage of OnAIR it does show that all the code used is compatible with those versions.
Python 3.7 was found to have many issues with running unit tests.
It is recommended to stop at 3.8 for now because allowing for Python 3.7 would require more time and effort.