### PR TITLE
150 generic tflite plugin

### DIFF
--- a/onair/config/tflite_test_config.ini
+++ b/onair/config/tflite_test_config.ini
@@ -1,0 +1,17 @@
+[FILES]
+TelemetryFilePath = onair/data/raw_telemetry_data/data_physics_generation/Errors
+TelemetryFile = 700_crash_to_earth_1.csv
+MetaFilePath = onair/data/telemetry_configs/
+MetaFile = data_physics_generation_CONFIG.json
+
+[DATA_HANDLING]
+DataSourceFile = onair/data_handling/csv_parser.py
+
+[PLUGINS]
+KnowledgeRepPluginDict = {'tflite_model_1':'plugins/tflite_model/__init__.py'}
+LearnersPluginDict = {'reporter':'plugins/reporter'}
+PlannersPluginDict = {}
+ComplexPluginDict = {}
+
+[OPTIONS]
+IO_Enabled = true

--- a/plugins/tflite_model/tflite_model_plugin.py
+++ b/plugins/tflite_model/tflite_model_plugin.py
@@ -1,0 +1,47 @@
+# GSC-19165-1, "The On-Board Artificial Intelligence Research (OnAIR) Platform"
+#
+# Copyright © 2023 United States Government as represented by the Administrator of
+# the National Aeronautics and Space Administration. No copyright is claimed in the
+# United States under Title 17, U.S. Code. All Other Rights Reserved.
+#
+# Licensed under the NASA Open Source Agreement version 1.3
+# See "NOSA GSC-19165-1 OnAIR.pdf"
+
+from onair.src.ai_components.ai_plugin_abstract.ai_plugin import AIPlugin
+import numpy as np
+
+try:
+    import tflite_runtime.interpreter as tflite
+except ModuleNotFoundError:
+    import tensorflow.lite as tflite
+else:
+    raise ModuleNotFoundError("tflite_runtime or tensorflow modules not found")
+
+class Plugin(AIPlugin):
+    def __init__(self, _name, _headers):
+        super().__init__(_name, _headers)
+        # your model goes here
+        model_path = r"tflite_models\yolo-v5-tflite-tflite-tflite-model-v1\1.tflite"
+        
+        self.interpreter = tflite.Interpreter(model_path)
+        self.interpreter.allocate_tensors()
+        self.input_details = self.interpreter.get_input_details()
+        self.output_details = self.interpreter.get_output_details()
+
+    
+    def update(self,low_level_data=[], high_level_data={}):
+        """
+        Given streamed data point, system should update internally
+        """
+        pass
+
+    def render_reasoning(self):
+        """
+        System should return its diagnosis
+        """
+        pass
+    
+    def generate_random_input(self):
+        pass
+    
+    

--- a/plugins/tflite_model/tflite_model_plugin.py
+++ b/plugins/tflite_model/tflite_model_plugin.py
@@ -10,38 +10,63 @@
 from onair.src.ai_components.ai_plugin_abstract.ai_plugin import AIPlugin
 import numpy as np
 
+# tflite_runtime is the bare minimum required to run tflite models
 try:
     import tflite_runtime.interpreter as tflite
 except ModuleNotFoundError:
     import tensorflow.lite as tflite
-else:
-    raise ModuleNotFoundError("tflite_runtime or tensorflow modules not found")
 
 class Plugin(AIPlugin):
     def __init__(self, _name, _headers):
         super().__init__(_name, _headers)
-        # your model goes here
-        model_path = r"tflite_models\yolo-v5-tflite-tflite-tflite-model-v1\1.tflite"
-        
+        # Your model here
+        model_path = r"tflite_models\mobilebert-tflite-default-v1\1.tflite"
+
+        # Load and initialize the model
         self.interpreter = tflite.Interpreter(model_path)
         self.interpreter.allocate_tensors()
         self.input_details = self.interpreter.get_input_details()
-        self.output_details = self.interpreter.get_output_details()
-
+        self.output_details = self.interpreter.get_output_details()        
+        self.input_tensors = None
+        self.output_tensors = None
     
     def update(self,low_level_data=[], high_level_data={}):
         """
         Given streamed data point, system should update internally
         """
-        pass
+        self.input_tensors = self.generate_random_input()
+        
+        # set inputs - this should handle models with multiple inputs
+        for model_input, tensor in zip(self.input_details, self.input_tensors):
+            self.interpreter.set_tensor(model_input['index'], tensor)
+            
+        self.interpreter.invoke()
+        
+        outputs = []
+        for model_output in self.output_details:
+            tensor = self.interpreter.get_tensor(model_output['index'])
+            outputs.append(tensor)
+            
+        self.output_tensors = tuple(outputs)
 
     def render_reasoning(self):
         """
         System should return its diagnosis
         """
-        pass
-    
-    def generate_random_input(self):
-        pass
-    
+        return self.output_tensors
+        
+            
+    def generate_random_input(self) -> tuple:
+        """
+        Generates random tensors to be used as the input of a tflite model.
+
+        Returns:
+            tuple of np.ndarray
+        """
+        tensors = []
+        for model_input in self.input_details:
+            rand_tensor = np.random.rand(*model_input['shape'])
+            rand_tensor = rand_tensor.astype(model_input['dtype'])
+            tensors.append(rand_tensor)
+        return tuple(tensors)
     


### PR DESCRIPTION
This plugin allows users to run a tflite model within onair. Currently the plugin generates random input data based on the model's input shapes. The 'render_reasoning` methods returns the outputs of a model inference on the random data.

These are the tflite models I've downloaded that I have tested this plugin with:

- https://www.kaggle.com/models/tensorflow/mobilebert/tfLite
- https://www.kaggle.com/models/tensorflow/spam-detection
- https://www.kaggle.com/models/kaggle/yolo-v5

Current TODO List:

- [ ] Unit testing
- [ ] Support for quantized models
- [ ] Support for edge tpu devices