### PR TITLE
Fix the missing assertion and functions identifier name correction

### DIFF
--- a/test/onair/src/util/test_print_io.py
+++ b/test/onair/src/util/test_print_io.py
@@ -116,7 +116,7 @@ def test_print_io_print_sim_header_prints_expected_strings(mocker):
 
     # Assert
     for i in range(3):
-        print_io.print.call_args_list[i].args == (expected_print[i],)
+        assert print_io.print.call_args_list[i].args == (expected_print[i],)
 
 
 # print_sim_step tests
@@ -574,7 +574,7 @@ def test_print_io_subsystem_str_returns_string_all_data_when_headers_tests_and_t
 
 
 # headers_string tests
-def test_print_io_format_status_returns_empty_string_when_headers_is_vacant():
+def test_print_io_headers_string_returns_empty_string_when_headers_is_vacant():
     # Arrange
     arg_headers = []
 
@@ -585,7 +585,7 @@ def test_print_io_format_status_returns_empty_string_when_headers_is_vacant():
     assert result == str()
 
 
-def test_print_io_format_status_returns_all_headers_in_formatted_string_when_occupied():
+def test_print_io_headers_string_returns_all_headers_in_formatted_string_when_occupied():
     # Arrange
     num_headers = pytest.gen.randint(1, 10)  # arbitrary from 1 to 10
     arg_headers = []
@@ -604,8 +604,6 @@ def test_print_io_format_status_returns_all_headers_in_formatted_string_when_occ
 
 
 # format_status tests
-
-
 def test_print_io_format_status_raises_KeyError_when_stat_is_string_and_not_in_status_color_keys():
     # Arrange
     arg_stat = str(MagicMock())


### PR DESCRIPTION
## Description
This pull request addresses the #181 issue. There are two bug in the `test_print_io.py` file related to test functionality and naming conventions.

## Fixes
- [x] Added the missing assertion to the `test_print_io_print_sim_header_prints_expected_strings` function to ensure proper verification and tested out as well. Here -> https://github.com/nasa/OnAIR/blob/main/test/onair/src/util/test_print_io.py#L119

- [x] Renamed two test functions to include `header_string` instead of `format_status` for better clarity and accuracy. Here -> https://github.com/nasa/OnAIR/blob/main/test/onair/src/util/test_print_io.py#L577-L609

## Testing
Verified the tests in 2 different ways:
- [x] Test the `test_print_io_print_sim_header_prints_expected_strings` function (which was not testing the functionality at all before) and the other two function where naming are corrected, which are`test_print_io_headers_string_returns_empty_string_when_headers_is_vacant` and `test_print_io_headers_string_returns_all_headers_in_formatted_string_when_occupied` individually by these commands:
```
python driver.py -t -k "test_print_io_print_sim_header_prints_expected_strings" -v
python driver.py -t -k "test_print_io_headers_string_returns_empty_string_when_headers_is_vacant" -v
python driver.py -t -k "test_print_io_headers_string_returns_all_headers_in_formatted_string_when_occupied" -v
```
- [x] Also, test the complete repo with the given command to analyze the coverage:
```
python driver.py -t
coverage report
```
Please review the changes and provide feedback. Thank you!😊