### PR TITLE
fix(core/plugins): eliminate mutable default arguments (#197)

### DIFF
--- a/onair/src/ai_components/learners_interface.py
+++ b/onair/src/ai_components/learners_interface.py
@@ -16,8 +16,10 @@ from ..util.data_conversion import *
 
 
 class LearnersInterface:
-    def __init__(self, headers, _learner_plugins={}):
+    def __init__(self, headers, _learner_plugins=None):
         assert len(headers) > 0, "Headers are required"
+        if _learner_plugins is None:
+            _learner_plugins = {}
         self.headers = headers
         self.learner_constructs = import_plugins(self.headers, _learner_plugins)
 

--- a/onair/src/ai_components/planners_interface.py
+++ b/onair/src/ai_components/planners_interface.py
@@ -16,8 +16,10 @@ from ..util.data_conversion import *
 
 
 class PlannersInterface:
-    def __init__(self, headers, _planner_plugins={}):
+    def __init__(self, headers, _planner_plugins=None):
         assert len(headers) > 0, "Headers are required"
+        if _planner_plugins is None:
+            _planner_plugins = {}
         self.headers = headers
         self.planner_constructs = import_plugins(self.headers, _planner_plugins)
 

--- a/onair/src/reasoning/complex_reasoning_interface.py
+++ b/onair/src/reasoning/complex_reasoning_interface.py
@@ -16,8 +16,10 @@ from ..util.plugin_import import import_plugins
 
 
 class ComplexReasoningInterface:
-    def __init__(self, headers, _reasoning_plugins={}):
+    def __init__(self, headers, _reasoning_plugins=None):
         assert len(headers) > 0, "Headers are required"
+        if _reasoning_plugins is None:
+            _reasoning_plugins = {}
         self.headers = headers
         self.reasoning_constructs = import_plugins(self.headers, _reasoning_plugins)
 

--- a/onair/src/reasoning/diagnosis.py
+++ b/onair/src/reasoning/diagnosis.py
@@ -49,12 +49,12 @@ class Diagnosis:
 
         return ret
 
-    def walkdown(self, mnemonic_name, used_mnemonics=[]):
+    def walkdown(self, mnemonic_name, used_mnemonics=None):
         """
         Go through the active AIComponents in an ordered way to decide on a diagnosis.
         There's a lot of specificity in this function until the method of combining the AIComponents is learned
         """
-        if len(used_mnemonics) == 0:
+        if used_mnemonics is None or len(used_mnemonics) == 0:
             used_mnemonics = copy.deepcopy(self.currently_faulting_mnemonics)
 
         if mnemonic_name == "":

--- a/onair/src/systems/telemetry_test_suite.py
+++ b/onair/src/systems/telemetry_test_suite.py
@@ -18,7 +18,11 @@ from collections import Counter
 
 
 class TelemetryTestSuite:
-    def __init__(self, headers=[], tests=[]):
+    def __init__(self, headers=None, tests=None):
+        if headers is None:
+            headers = []
+        if tests is None:
+            tests = []
         self.dataFields = headers
         self.tests = tests
         self.latest_results = None
@@ -32,7 +36,9 @@ class TelemetryTestSuite:
     ################################################
     ################  Running Tests  ###############
 
-    def execute_suite(self, updated_frame, sync_data={}):
+    def execute_suite(self, updated_frame, sync_data=None):
+        if sync_data is None:
+            sync_data = {}
         results = []
         for i in range(len(updated_frame)):
             results.append(self.run_tests(i, updated_frame[i], sync_data))

--- a/onair/src/systems/vehicle_rep.py
+++ b/onair/src/systems/vehicle_rep.py
@@ -22,8 +22,10 @@ from ..util.plugin_import import import_plugins
 
 
 class VehicleRepresentation:
-    def __init__(self, headers, tests, _knowledge_rep_plugins={}):
+    def __init__(self, headers, tests, _knowledge_rep_plugins=None):
         assert len(headers) == len(tests)
+        if _knowledge_rep_plugins is None:
+            _knowledge_rep_plugins = {}
         self.headers = headers
         self.knowledge_synthesis_constructs = import_plugins(
             self.headers, _knowledge_rep_plugins
@@ -73,7 +75,9 @@ class VehicleRepresentation:
     def get_batch_status_reports(self, batch_data):
         return
 
-    def get_state_information(self, scope=["status"]):
+    def get_state_information(self, scope=None):
+        if scope is None:
+            scope = ["status"]
         state_info = {}
         for construct in self.knowledge_synthesis_constructs:
             state_info[construct.component_name] = construct.render_reasoning()

--- a/test/onair/src/systems/test_telemetry_test_suite.py
+++ b/test/onair/src/systems/test_telemetry_test_suite.py
@@ -1530,3 +1530,21 @@ def test_TelemetryTestSuite_get_status_specific_mnemonics_default_given_status_i
 
     # Assert
     assert result == [expected_name]
+
+
+def test_TelemetryTestSuite__init__does_not_share_mutable_defaults_between_instances():
+    # Regression for #197: previously `headers=[]` and `tests=[]` were mutable
+    # default arguments, so every no-arg instance shared the SAME list object.
+    # Mutating one instance leaked into others. The fix defaults to None and
+    # builds a fresh list per call.
+    a = TelemetryTestSuite()
+    b = TelemetryTestSuite()
+
+    assert a.dataFields is not b.dataFields
+    assert a.tests is not b.tests
+
+    a.dataFields.append("leaked")
+    a.tests.append(["leaked"])
+
+    assert b.dataFields == []
+    assert b.tests == []


### PR DESCRIPTION
## Summary
- Resolves #197: mutable default arguments (lists/dicts as \=[]\ / \={}\) are created **once** at function-definition time and shared by every call. Any in-place mutation then leaks state across calls/instances -- a silent, hard-to-find defect.
- Defaulted to \None\ and build a fresh \[]\/\{}\ inside the body instead.

### Files changed
- \learners_interface.py\, \planners_interface.py\, \complex_reasoning_interface.py\: \_*_plugins={}\ -> \None\ + fresh dict.
- \diagnosis.py\: \used_mnemonics=[]\ -> \None\ (an empty arg still triggers the existing \copy.deepcopy\ path, preserving behavior).
- \	elemetry_test_suite.py\: \headers=[]\, \	ests=[]\, \sync_data={}\ -> \None\ + fresh.
- \ehicle_rep.py\: \_knowledge_rep_plugins={}\ and \scope=['status']\ -> \None\ + fresh.

## Verification
- Added a regression test (\	est_TelemetryTestSuite__init__does_not_share_mutable_defaults_between_instances\) proving two no-arg instances no longer share the same list object.
- Full unit suite for the touched modules passes (95 tests green).

Fixes #197